### PR TITLE
Simple improvement to "disable tweens" to consider leftmost keyframe when jumping between 2 frames

### DIFF
--- a/lua/smh/client/render.lua
+++ b/lua/smh/client/render.lua
@@ -20,7 +20,7 @@ local function RenderTick()
 		RunConsoleCommand(command);
 	end);
 
-	SMH.Data.Position = newPos; --put line down here
+	SMH.Data.Position = newPos;
 
 end
 

--- a/lua/smh/server/positioning.lua
+++ b/lua/smh/server/positioning.lua
@@ -87,7 +87,15 @@ function SMH.PositionEntity(player, entity, framepos)
 				mod:LoadBetween(player, entity, data1, data2, perc);
 			end
 		end
+	else
+		for name, mod in pairs(SMH.Modifiers) do
+			local data1 = frame1.EntityData[name];
+			if data1 ~= nil then
+				mod:Load(player, entity, frame1.EntityData[name]);
+			end
+		end
 	end
+	
 
 end
 


### PR DESCRIPTION
also removed a useless comment i've left for myself in render.lua