### PR TITLE
Small tweaks to make UI less confusing, shouldn't impact previous...

### DIFF
--- a/lua/smh/client.lua
+++ b/lua/smh/client.lua
@@ -17,7 +17,7 @@ local function BindData(container, key)
     local output = Rx.Subject.create();
     local changing = false;
     
-    container:_Listen(key, function(contianer, _, value)
+    container:_Listen(key, function(container, _, value)
         if not changing then
             changing = true;
             output(value);

--- a/lua/smh/client/concommands.lua
+++ b/lua/smh/client/concommands.lua
@@ -14,7 +14,7 @@ local function Setup()
 
 	concommand.Add("smh_next", function()
 		local pos = SMH.Data.Position + 1;
-		if pos > SMH.Data.PlaybackLength then
+		if pos >= SMH.Data.PlaybackLength then
 			pos = 0;
 		end
 		SMH.Data.Position = pos;
@@ -23,7 +23,7 @@ local function Setup()
 	concommand.Add("smh_previous", function()
 		local pos = SMH.Data.Position - 1;
 		if pos < 0 then
-			pos = SMH.Data.PlaybackLength;
+			pos = SMH.Data.PlaybackLength - 1;
 		end
 		SMH.Data.Position = pos;
 	end);

--- a/lua/smh/client/derma/frame_pointer.lua
+++ b/lua/smh/client/derma/frame_pointer.lua
@@ -137,7 +137,7 @@ local function Create(parent, pointyBottom)
 		local width = endX - startX;
 
 		local targetPos = math.Round(scrollOffset + (targetX / width) * zoom);
-		targetPos = targetPos < 0 and 0 or (targetPos > totalFrames and totalFrames - 1 or targetPos);
+		targetPos = targetPos < 0 and 0 or (targetPos > totalFrames - 1 and totalFrames - 1 or targetPos);
 
 		distinctOutputPositionStream(targetPos);
 	

--- a/lua/smh/client/derma/smh_menu.lua
+++ b/lua/smh/client/derma/smh_menu.lua
@@ -227,7 +227,7 @@ local function Setup(parent)
 	local combinedPositionStream = Rx.BehaviorSubject.create(0);
 	inputPositionStream:merge(outputPositionStream):subscribe(combinedPositionStream);
 	Rx.Observable.combineLatest(combinedPositionStream, timelineLengthStream)
-		:map(function(position, timelineLength) return "Position: " .. position .. " / " .. timelineLength end)
+		:map(function(position, timelineLength) return "Position: " .. (position + 1) .. " / " .. timelineLength end)
 		:subscribe(function(text)
 			positionLabel:SetText(text);
 			positionLabel:SizeToContents();

--- a/lua/smh/server/playback.lua
+++ b/lua/smh/server/playback.lua
@@ -10,7 +10,7 @@ hook.Add("Think", "SMHPlaybackTick", function()
 		pb.Position = pb.Position + FrameTime() * pb.PlaybackRate;
 		local newPos = math.floor(pb.Position);
 
-		if newPos > pb.PlaybackLength then
+		if newPos > pb.PlaybackLength - 1 then
 			pb.Position = 0;
 			newPos = 0;
 		end


### PR DESCRIPTION
…saves in any way - UI-wise first frame is now 1 instead of 0, code wise everything is the same, + now it shouldn't be possible to go past last frame by smh_next/previous or dragging past it.