### PR TITLE
Tweak to render function, now it should start at frame 0... 

### DIFF
--- a/lua/smh/client/render.lua
+++ b/lua/smh/client/render.lua
@@ -5,7 +5,7 @@ SMH.RenderTimerName = "SMHRender";
 local function RenderTick()
 
 	local newPos = SMH.Data.Position + 1;
-	if newPos >= SMH.Data.PlaybackLength then
+	if newPos > SMH.Data.PlaybackLength then
 		SMH.StopRender();
 		return;
 	end
@@ -15,11 +15,12 @@ local function RenderTick()
 		command = "screenshot";
 	end
 
-	timer.Create(SMH.RenderTimerName .. "Sub", 0.4, 1, function()
+	timer.Create(SMH.RenderTimerName .. "Sub", 0.2, 1, function()
 		RunConsoleCommand(command);
+		timer.Simple(0.4, function()
+			SMH.Data.Position = newPos;
+		end);
 	end);
-
-	SMH.Data.Position = newPos;
 
 end
 
@@ -29,7 +30,7 @@ function SMH.StartRender(useScreenshot)
 		useScreenshot = false;
 	end
 
-	SMH.Data.Position = -1;
+	SMH.Data.Position = 0;
 
 	LocalPlayer():EmitSound("buttons/blip1.wav");
 


### PR DESCRIPTION
and go through whole frame count

Previously there was a little problem that if render process was called and immediately stopped, smh would set itself to frame -1, which isn't accessible through normal means, which may lead to someone recording frame there by accident. For this tweak I've mostly messed a bit more with timers, made delay before inputting screenshot command little bit smaller and added timer that'll increment the current frame by 1 after 0.4 seconds.