### PR TITLE
Some fixes to make refactor more like it was before

### DIFF
--- a/lua/autorun/client/derma_utils.lua
+++ b/lua/autorun/client/derma_utils.lua
@@ -8,11 +8,33 @@ end
 
 -- For DListView
 function PANEL:UpdateLines(lines)
-	self:ClearSelection()
+--[[	self:ClearSelection()
 	self:Clear()
 	for _, line in pairs(lines) do
 		self:AddLine(line)
+	end]]
+	local sorting = {}
+	local existing = {}
+	
+	for k, line in pairs(lines) do -- turn lines stuff into a "sorting" table
+		sorting[line] = true
 	end
+	
+	for k, line in pairs(self:GetLines()) do -- first we remove lines that are missing from the sorting table
+		if !sorting[line:GetValue(1)] then
+			local _, selected = self:GetSelectedLine()
+			if selected == line then self:ClearSelection() end -- clear selection if the removed line was selected
+			self:RemoveLine(line:GetID())
+			continue
+		end
+		existing[line:GetValue(1)] = true
+	end
+	
+	for line, _ in pairs(sorting) do
+		if existing[line] then continue end
+		self:AddLine(line)
+	end
+	self:SortByColumn(1)
 end
 
 -- For number wangs

--- a/lua/smh/client.lua
+++ b/lua/smh/client.lua
@@ -1,5 +1,7 @@
 include("shared.lua")
 
+include("client/state.lua")
+
 include("client/derma/frame_panel.lua")
 include("client/derma/frame_pointer.lua")
 include("client/derma/load.lua")
@@ -13,5 +15,4 @@ include("client/controller.lua")
 include("client/highlighter.lua")
 include("client/renderer.lua")
 include("client/settings.lua")
-include("client/state.lua")
 include("client/ui.lua")

--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -168,6 +168,18 @@ function CTRL.OpenHelp()
     gui.OpenURL("https://github.com/Winded/StopMotionHelper/blob/master/TUTORIAL.md")
 end
 
+function CTRL.IsRendering(rendering)
+	net.Start(SMH.MessageTypes.IsRendering)
+    net.WriteBool(rendering)
+    net.SendToServer()
+end
+
+function CTRL.UpdateGhostState()
+	net.Start(SMH.MessageTypes.UpdateGhostState)
+	net.WriteTable(SMH.Settings.GetAll())
+	net.SendToServer()
+end
+
 SMH.Controller = CTRL
 
 local function SetFrameResponse(msgLength)

--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -48,7 +48,7 @@ end
 
 function CTRL.StartPlayback()
     net.Start(SMH.MessageTypes.StartPlayback)
-    net.WriteUInt(0, INT_BITCOUNT)
+    net.WriteUInt(SMH.State.Frame, INT_BITCOUNT)
     net.WriteUInt(SMH.State.PlaybackLength - 1, INT_BITCOUNT)
     net.WriteUInt(SMH.State.PlaybackRate, INT_BITCOUNT)
     net.WriteTable(SMH.Settings.GetAll())

--- a/lua/smh/client/derma/frame_pointer.lua
+++ b/lua/smh/client/derma/frame_pointer.lua
@@ -101,6 +101,21 @@ function PANEL:OnMousePressed(mousecode)
 
 	self:MouseCapture(true)
 	self._dragging = true
+	
+	local parent = self:GetParent() -- this is the part from OnCursorMoved(), mostly needed to the cases when we copy and paste a frame on top of itself, as by default it seems to go back to frame 0
+
+	local cursorX, cursorY = parent:CursorPos()
+	local startX, endX = unpack(parent.FrameArea)
+	
+	local targetX = cursorX - startX
+	local width = endX - startX
+
+	local targetPos = math.Round(parent.ScrollOffset + (targetX / width) * parent.Zoom)
+	targetPos = targetPos < 0 and 0 or (targetPos >= parent.TotalFrames and parent.TotalFrames - 1 or targetPos)
+
+	if targetPos ~= self._frame then
+		self:SetFrame(targetPos)
+	end
 end
 
 function PANEL:OnMouseReleased(mousecode)

--- a/lua/smh/client/derma/load.lua
+++ b/lua/smh/client/derma/load.lua
@@ -1,4 +1,5 @@
 local PANEL = {}
+local LastSelectedSave
 
 function PANEL:Init()
 
@@ -54,12 +55,21 @@ function PANEL:LoadSelected()
 	local _, selectedSave = self.FileList:GetSelectedLine()
 	local _, selectedEntity = self.EntityList:GetSelectedLine()
 
-	if not IsValid(selectedSave) or not IsValid(selectedEntity) then
-		return
+	if not IsValid(selectedSave) then
+		selectedSave = LastSelectedSave
 	end
-
+	
+	if IsValid(selectedSave) and IsValid(selectedEntity) then
+		self:OnLoadRequested(selectedSave:GetValue(1), selectedEntity:GetValue(1), false)
+		LastSelectedSave = selectedSave:GetValue(1)
+	elseif IsValid(selectedSave) then
+		LastSelectedSave = selectedSave:GetValue(1)
+	elseif IsValid(selectedEntity) and LastSelectedSave then
+		self:OnLoadRequested(LastSelectedSave, selectedEntity:GetValue(1), false)
+	end
+	
 	-- TODO clientside support for loading and saving
-	self:OnLoadRequested(selectedSave:GetValue(1), selectedEntity:GetValue(1), false)
+	
 end
 
 function PANEL:OnModelListRequested(path, loadFromClient) end

--- a/lua/smh/client/derma/load.lua
+++ b/lua/smh/client/derma/load.lua
@@ -1,11 +1,16 @@
 local PANEL = {}
-local LastSelectedSave
 
 function PANEL:Init()
 
 	self:SetTitle("Load")
 	self:SetDeleteOnClose(false)
-
+	self:SetSizable(true)
+	
+	self:SetSize(250, 210)
+	self:SetMinWidth(250)
+	self:SetMinHeight(210)
+	self:SetPos(ScrW() / 2 - self:GetWide() / 2, ScrH() / 2 - self:GetTall() / 2)
+	
 	self.FileList = vgui.Create("DListView", self)
 	self.FileList:AddColumn("Saved scenes")
 	self.FileList:SetMultiSelect(false)
@@ -22,25 +27,45 @@ function PANEL:Init()
 	self.Load.DoClick = function()
 		self:LoadSelected()
 	end
-
+	
+	self.SaveEntity = vgui.Create("DLabel", self)
+	self.SaveEntity:SetText("Save's model: " .. "Placeholder")
+	
+	self.SaveMap = vgui.Create("DLabel", self)
+	self.SaveMap:SetText("Save's map: " .. "Placeholder")
+	
+	self.SelectedEnt = vgui.Create("DLabel", self)
+	self.SelectedEnt:SetText("Selected model: " .. "nil")
+	
 end
 
 function PANEL:PerformLayout(width, height)
-
+	
 	self.BaseClass.PerformLayout(self, width, height)
 
-	self:SetSize(250, 210)
-	self:SetPos(ScrW() / 2 - self:GetWide() / 2, ScrH() / 2 - self:GetTall() / 2)
-
 	self.FileList:SetPos(5, 30)
-	self.FileList:SetSize(self:GetWide() / 2 - 5 - 5, 150)
+	self.FileList:SetSize(self:GetWide() / 2 - 5 - 5, 150 * (self:GetTall() / 210))
 
 	self.EntityList:SetPos(self:GetWide() / 2 + 5, 30)
-	self.EntityList:SetSize(self:GetWide() / 2 - 5 - 5, 150)
-
-	self.Load:SetPos(self:GetWide() - 60 - 5, 182)
+	self.EntityList:SetSize(self:GetWide() / 2 - 5 - 5, 150 * (self:GetTall() / 210))
+	
+	self.SaveEntity:SetPos(5, 30 + self.FileList:GetTall() + 5 )
+	self.SaveEntity:SetSize(self:GetWide() * 2 / 3, 15)
+	
+	self.SaveMap:SetPos(5, 30 + self.FileList:GetTall() + 25 )
+	self.SaveMap:SetSize(self:GetWide() * 2 / 3, 15)
+	
+	self.SelectedEnt:SetPos(5, 30 + self.FileList:GetTall() + 45 )
+	self.SelectedEnt:SetSize(self:GetWide() * 2 / 3, 15)
+	
+	self.Load:SetPos(self:GetWide() - 60 - 5, self:GetTall() - 28)
 	self.Load:SetSize(60, 20)
 
+end
+
+function PANEL:UpdateSelectedEnt(ent)
+	local SelectedName = IsValid(ent) and ent:GetModel() or "nil"
+	self.SelectedEnt:SetText("Selected model: " .. SelectedName)
 end
 
 function PANEL:SetSaves(saves)
@@ -55,17 +80,14 @@ function PANEL:LoadSelected()
 	local _, selectedSave = self.FileList:GetSelectedLine()
 	local _, selectedEntity = self.EntityList:GetSelectedLine()
 	
-	if IsValid(selectedSave) and IsValid(selectedEntity) then
-		self:OnLoadRequested(selectedSave:GetValue(1), selectedEntity:GetValue(1), false)
-		LastSelectedSave = selectedSave:GetValue(1)
-	elseif IsValid(selectedSave) then
-		LastSelectedSave = selectedSave:GetValue(1)
-	elseif IsValid(selectedEntity) and LastSelectedSave then
-		self:OnLoadRequested(LastSelectedSave, selectedEntity:GetValue(1), false)
-	end
-	
 	-- TODO clientside support for loading and saving
 	
+	if not IsValid(selectedSave) or not IsValid(selectedEntity) then
+		return
+	end
+
+	-- TODO clientside support for loading and saving
+	self:OnLoadRequested(selectedSave:GetValue(1), selectedEntity:GetValue(1), false)
 end
 
 function PANEL:OnModelListRequested(path, loadFromClient) end

--- a/lua/smh/client/derma/load.lua
+++ b/lua/smh/client/derma/load.lua
@@ -54,10 +54,6 @@ end
 function PANEL:LoadSelected()
 	local _, selectedSave = self.FileList:GetSelectedLine()
 	local _, selectedEntity = self.EntityList:GetSelectedLine()
-
-	if not IsValid(selectedSave) then
-		selectedSave = LastSelectedSave
-	end
 	
 	if IsValid(selectedSave) and IsValid(selectedEntity) then
 		self:OnLoadRequested(selectedSave:GetValue(1), selectedEntity:GetValue(1), false)

--- a/lua/smh/client/derma/save.lua
+++ b/lua/smh/client/derma/save.lua
@@ -4,6 +4,12 @@ function PANEL:Init()
 
 	self:SetTitle("Save")
 	self:SetDeleteOnClose(false)
+	self:SetSizable(true)
+	
+	self:SetSize(250, 250)
+	self:SetMinWidth(250)
+	self:SetMinHeight(250)
+	self:SetPos(ScrW() / 2 - self:GetWide() / 2, ScrH() / 2 - self:GetTall() / 2)
 
 	self.FileName = vgui.Create("DTextEntry", self)
 	self.FileName.Label = vgui.Create("DLabel", self)
@@ -38,20 +44,17 @@ function PANEL:PerformLayout(width, height)
 	
 	self.BaseClass.PerformLayout(self, width, height)
 
-	self:SetSize(250, 250)
-	self:SetPos(ScrW() / 2 - self:GetWide() / 2, ScrH() / 2 - self:GetTall() / 2)
-
 	self.FileName:SetPos(5, 45)
 	self.FileName:SetSize(self:GetWide() - 5 - 5, 20)
 	self.FileName.Label:SetPos(5, 30)
 
 	self.FileList:SetPos(5, 67)
-	self.FileList:SetSize(self:GetWide() - 5 - 5, 150)
+	self.FileList:SetSize(self:GetWide() - 5 - 5, 150 * (self:GetTall() / 250))
 
-	self.Save:SetPos(self:GetWide() - 60 - 5, 219)
+	self.Save:SetPos(self:GetWide() - 60 - 5, self:GetTall() - 31)
 	self.Save:SetSize(60, 20)
 
-	self.Delete:SetPos(self:GetWide() - 60 - 5 - 60 - 5, 219)
+	self.Delete:SetPos(self:GetWide() - 60 - 5 - 60 - 5, self:GetTall() - 31)
 	self.Delete:SetSize(60, 20)
 
 end

--- a/lua/smh/client/derma/world_clicker.lua
+++ b/lua/smh/client/derma/world_clicker.lua
@@ -1,14 +1,5 @@
 local BaseClass = baseclass.Get("EditablePanel")
 local PANEL = {}
-local ClickerEntity = nil;
-
-hook.Add("EntityRemoved", "SMHWorldClickerEntityRemoved", function(entity)
-
-	if entity == ClickerEntity then
-		SMH.Controller.SelectEntity(nil)
-	end
-
-end)
 
 function PANEL:Init()
 
@@ -41,7 +32,6 @@ function PANEL:OnMousePressed(mousecode)
 	local trace = util.TraceLine(util.GetPlayerTrace(LocalPlayer()))
 	if IsValid(trace.Entity) then
 		self:OnEntitySelected(trace.Entity)
-		ClickerEntity = trace.Entity
 	end
 end
 

--- a/lua/smh/client/derma/world_clicker.lua
+++ b/lua/smh/client/derma/world_clicker.lua
@@ -1,5 +1,14 @@
 local BaseClass = baseclass.Get("EditablePanel")
 local PANEL = {}
+local ClickerEntity = nil;
+
+hook.Add("EntityRemoved", "SMHWorldClickerEntityRemoved", function(entity)
+
+	if entity == ClickerEntity then
+		SMH.Controller.SelectEntity(nil)
+	end
+
+end)
 
 function PANEL:Init()
 
@@ -32,6 +41,7 @@ function PANEL:OnMousePressed(mousecode)
 	local trace = util.TraceLine(util.GetPlayerTrace(LocalPlayer()))
 	if IsValid(trace.Entity) then
 		self:OnEntitySelected(trace.Entity)
+		ClickerEntity = trace.Entity
 	end
 end
 

--- a/lua/smh/client/renderer.lua
+++ b/lua/smh/client/renderer.lua
@@ -2,29 +2,42 @@ local UseScreenshot = false
 local TimerName = "SMHRender"
 local Rendering = false
 
+local MGR = {}
+
+function MGR.IsRendering()
+    return IsRendering
+end
+
+function MGR.Stop()
+	if timer.Exists(TimerName) then
+		timer.Remove(TimerName)
+	end
+
+	LocalPlayer():EmitSound("buttons/button1.wav");
+
+    IsRendering = false
+end
+
 local function RenderTick()
+	local newPos = SMH.State.Frame + 1
+	if newPos > SMH.State.PlaybackLength then
+		MGR.Stop()
+		return
+	end
 
 	local command = "jpeg"
 	if UseScreenshot then
 		command = "screenshot"
 	end
 
-    RunConsoleCommand(command)
+	timer.Simple(0.2, function()
+		RunConsoleCommand(command)
 
-	local newPos = SMH.State.Frame + 1
-	if newPos >= SMH.State.PlaybackLength then
-		MGR.Stop()
-		return
-	end
+		timer.Simple(0.4, function()
+			SMH.Controller.SetFrame(newPos)
+		end)
+	end)
 
-    SMH.Controller.SetFrame(newPos)
-
-end
-
-local MGR = {}
-
-function MGR.IsRendering()
-    return IsRendering
 end
 
 function MGR.Start(useScreenshot)
@@ -36,16 +49,6 @@ function MGR.Start(useScreenshot)
 
 	timer.Create(TimerName, 1, 0, RenderTick)
     IsRendering = true
-end
-
-function MGR.Stop()
-	if timer.Exists(TimerName) then
-		timer.Remove(TimerName)
-	end
-
-	LocalPlayer():EmitSound("buttons/button1.wav");
-
-    IsRendering = false
 end
 
 SMH.Renderer = MGR

--- a/lua/smh/client/renderer.lua
+++ b/lua/smh/client/renderer.lua
@@ -1,6 +1,6 @@
 local UseScreenshot = false
 local TimerName = "SMHRender"
-local Rendering = false
+local IsRendering = false
 
 local MGR = {}
 
@@ -12,43 +12,45 @@ function MGR.Stop()
 	if timer.Exists(TimerName) then
 		timer.Remove(TimerName)
 	end
-
+	
 	LocalPlayer():EmitSound("buttons/button1.wav");
 
     IsRendering = false
+	SMH.Controller.IsRendering(IsRendering)
 end
 
 local function RenderTick()
 	local newPos = SMH.State.Frame + 1
-	if newPos > SMH.State.PlaybackLength then
-		MGR.Stop()
-		return
-	end
-
+	
 	local command = "jpeg"
 	if UseScreenshot then
 		command = "screenshot"
 	end
+	
+	RunConsoleCommand(command)
+	
+	if newPos >= SMH.State.PlaybackLength then
+		MGR.Stop()
+		return
+	end
 
-	timer.Simple(0.2, function()
-		RunConsoleCommand(command)
-
-		timer.Simple(0.4, function()
-			SMH.Controller.SetFrame(newPos)
-		end)
+	timer.Simple(0.4, function()
+		SMH.Controller.SetFrame(newPos)
 	end)
-
+	
 end
 
 function MGR.Start(useScreenshot)
     UseScreenshot = useScreenshot
-
+	
+	IsRendering = true
+	SMH.Controller.IsRendering(IsRendering)
+	
     SMH.Controller.SetFrame(0)
-
+	
 	LocalPlayer():EmitSound("buttons/blip1.wav")
 
 	timer.Create(TimerName, 1, 0, RenderTick)
-    IsRendering = true
 end
 
 SMH.Renderer = MGR

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -5,6 +5,7 @@ local LoadMenu = nil
 local FrameToKeyframe = {}
 local KeyframePointers = {}
 local KeyframeEasingData = {}
+local ClickerEntity = nil
 
 local function CreateCopyPointer(keyframeId)
     local pointer = WorldClicker.MainMenu.FramePanel:CreateFramePointer(
@@ -58,6 +59,8 @@ local function AddCallbacks()
 
     WorldClicker.OnEntitySelected = function(_, entity)
         SMH.Controller.SelectEntity(entity)
+		LoadMenu:UpdateSelectedEnt(entity)
+		ClickerEntity = entity
     end
 
     WorldClicker.MainMenu.OnRequestStateUpdate = function(_, newState)
@@ -127,6 +130,14 @@ local function AddCallbacks()
     end
 
 end
+
+hook.Add("EntityRemoved", "SMHWorldClickerEntityRemoved", function(entity)
+
+	if entity == ClickerEntity then
+		WorldClicker:OnEntitySelected(nil)
+	end
+
+end)
 
 hook.Add("InitPostEntity", "SMHMenuSetup", function()
 

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -94,6 +94,19 @@ local function AddCallbacks()
 
     WorldClicker.Settings.OnSettingsUpdated = function(_, newSettings)
         SMH.Controller.UpdateSettings(newSettings)
+		local ghoststuff = {
+			GhostPrevFrame = true,
+			GhostNextFrame = true,
+			OnionSkin = true,
+			GhostAllEntities = true,
+			GhostTransparency = true,
+		}
+		for name, value in pairs(newSettings) do
+			if ghoststuff[name] then
+				SMH.Controller.UpdateGhostState()
+				break
+			end
+		end
     end
     WorldClicker.Settings.OnRequestOpenHelp = function()
         SMH.Controller.OpenHelp()

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -16,6 +16,13 @@ local function CreateCopyPointer(keyframeId)
     pointer.OnPointerReleased = function(_, frame)
         SMH.Controller.CopyKeyframe(keyframeId, frame)
         WorldClicker.MainMenu.FramePanel:DeleteFramePointer(pointer)
+		
+		for id, pointer in pairs(KeyframePointers) do
+			if id == keyframeId + 1 then continue end
+			if pointer:GetFrame() == frame then
+				SMH.Controller.DeleteKeyframe(id)
+			end
+		end
     end
 end
 
@@ -28,6 +35,13 @@ local function NewKeyframePointer(keyframeId)
 
     pointer.OnPointerReleased = function(_, frame)
         SMH.Controller.UpdateKeyframe(keyframeId, { Frame = frame })
+		
+		for id, pointer in pairs(KeyframePointers) do
+			if id == keyframeId then continue end
+			if pointer:GetFrame() == frame then
+				SMH.Controller.DeleteKeyframe(id)
+			end
+		end
     end
     pointer.OnCustomMousePressed = function(_, mousecode)
         if mousecode == MOUSE_RIGHT and not input.IsKeyDown(KEY_LCONTROL) then
@@ -108,7 +122,7 @@ hook.Add("InitPostEntity", "SMHMenuSetup", function()
     WorldClicker.MainMenu = vgui.Create("SMHMenu", WorldClicker)
 
     WorldClicker.Settings = vgui.Create("SMHSettings", WorldClicker)
-	WorldClicker.Settings:SetPos(ScrW() - 165, ScrH() - 275)
+	WorldClicker.Settings:SetPos(ScrW() - 250, ScrH() - 75 - 225)
 	WorldClicker.Settings:SetVisible(false)
 
     SaveMenu = vgui.Create("SMHSave")

--- a/lua/smh/modifiers/advcamera.lua
+++ b/lua/smh/modifiers/advcamera.lua
@@ -18,6 +18,7 @@ function MOD:Save(entity)
 	data.Nearz = entity:GetNearZ();
 	data.Farz = entity:GetFarZ();
 	data.Roll = entity:GetRoll();
+	data.Offset = entity:GetViewOffset();
 
 	return data;
 
@@ -31,6 +32,7 @@ function MOD:Load(entity, data)
 	entity:SetNearZ(data.Nearz);
 	entity:SetFarZ(data.Farz);
 	entity:SetRoll(data.Roll);
+	entity:SetViewOffset(data.Offset);
 
 end
 
@@ -42,5 +44,6 @@ function MOD:LoadBetween(entity, data1, data2, percentage)
 	entity:SetNearZ(SMH.LerpLinear(data1.Nearz, data2.Nearz, percentage));
 	entity:SetFarZ(SMH.LerpLinear(data1.Farz, data2.Farz, percentage));
 	entity:SetRoll(SMH.LerpLinear(data1.Roll, data2.Roll, percentage));
+	entity:SetViewOffset(SMH.LerpLinearVector(data1.Offset, data2.Offset, percentage));
 	
 end

--- a/lua/smh/modifiers/softlamps.lua
+++ b/lua/smh/modifiers/softlamps.lua
@@ -21,6 +21,7 @@ function MOD:Save(entity)
 	data.Color = entity:GetLightColor();
 	data.ShapeRadius = entity:GetShapeRadius();
 	data.FocalPoint = entity:GetFocalDistance();
+	data.Offset = entity:GetLightOffset();
 
 	return data;
 
@@ -37,6 +38,7 @@ function MOD:Load(entity, data)
 	entity:SetLightColor(data.Color);
 	entity:SetShapeRadius(data.ShapeRadius);
 	entity:SetFocalDistance(data.FocalPoint);
+	entity:SetLightOffset(data.Offset);
 
 end
 
@@ -51,5 +53,6 @@ function MOD:LoadBetween(entity, data1, data2, percentage)
 	entity:SetLightColor(SMH.LerpLinearVector(data1.Color, data2.Color, percentage));
 	entity:SetShapeRadius(SMH.LerpLinear(data1.ShapeRadius, data2.ShapeRadius, percentage));
 	entity:SetFocalDistance(SMH.LerpLinear(data1.FocalPoint, data2.FocalPoint, percentage));
+	entity:SetLightOffset(SMH.LerpLinearVector(data1.Offset, data2.Offset, percentage));
 	
 end

--- a/lua/smh/server/controller.lua
+++ b/lua/smh/server/controller.lua
@@ -14,7 +14,6 @@ end
 
 local function SelectEntity(msgLength, player)
     local entity = net.ReadEntity()
-
     SMH.GhostsManager.SelectEntity(player, entity)
 
     local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entity)

--- a/lua/smh/server/controller.lua
+++ b/lua/smh/server/controller.lua
@@ -182,6 +182,11 @@ local function DeleteSave(msgLength, player)
     net.Send(player)
 end
 
+local function IsRendering(msgLength, player)
+	local rendering = net.ReadBool()
+	SMH.GhostsManager.IsRendering = rendering
+end
+
 for _, message in pairs(SMH.MessageTypes) do
     util.AddNetworkString(message)
 end
@@ -198,6 +203,7 @@ net.Receive(SMH.MessageTypes.DeleteKeyframe, DeleteKeyframe)
 net.Receive(SMH.MessageTypes.StartPlayback, StartPlayback)
 net.Receive(SMH.MessageTypes.StopPlayback, StopPlayback)
 
+net.Receive(SMH.MessageTypes.IsRendering, IsRendering)
 net.Receive(SMH.MessageTypes.UpdateGhostState, UpdateGhostState)
 
 net.Receive(SMH.MessageTypes.GetServerSaves, GetServerSaves)

--- a/lua/smh/server/controller.lua
+++ b/lua/smh/server/controller.lua
@@ -77,7 +77,6 @@ local function DeleteKeyframe(msgLength, player)
     local id = net.ReadUInt(INT_BITCOUNT)
 
     SMH.KeyframeManager.Delete(player, id)
-
     net.Start(SMH.MessageTypes.DeleteKeyframeResponse)
     net.WriteUInt(id, INT_BITCOUNT)
     net.Send(player)

--- a/lua/smh/server/ghosts_manager.lua
+++ b/lua/smh/server/ghosts_manager.lua
@@ -96,7 +96,7 @@ function MGR.UpdateState(player, frame, settings)
             elseif settings.GhostNextFrame and nextKeyframe.Frame > frame then
                 local g = CreateGhost(entity, Color(0, 200, 0, alpha))
                 table.insert(ghosts, g)
-                SetGhostFrame(entity, g, prevKeyframe.Modifiers)
+                SetGhostFrame(entity, g, nextKeyframe.Modifiers)
             end
         else
             if settings.GhostPrevFrame then

--- a/lua/smh/server/ghosts_manager.lua
+++ b/lua/smh/server/ghosts_manager.lua
@@ -1,4 +1,5 @@
 local GhostData = {}
+local LastFrame = 0
 
 local function CreateGhost(entity, color)
     local class = entity:GetClass()
@@ -37,6 +38,8 @@ end
 
 local MGR = {}
 
+MGR.IsRendering = false
+
 function MGR.SelectEntity(player, entity)
     if not GhostData[player] then
         GhostData[player] = {
@@ -49,6 +52,8 @@ function MGR.SelectEntity(player, entity)
 end
 
 function MGR.UpdateState(player, frame, settings)
+	LastFrame = frame
+	
     if not GhostData[player] then
         return
     end
@@ -61,8 +66,8 @@ function MGR.UpdateState(player, frame, settings)
         end
     end
     table.Empty(ghosts)
-
-    if not settings.GhostPrevFrame and not settings.GhostNextFrame and not settings.OnionSkin then
+	
+    if not settings.GhostPrevFrame and not settings.GhostNextFrame and not settings.OnionSkin or MGR.IsRendering then
         return
     end
 
@@ -120,6 +125,10 @@ function MGR.UpdateState(player, frame, settings)
         end
 
     end
+end
+
+function MGR.UpdateSettings(player, settings)
+	MGR.UpdateState(player, LastFrame, settings)
 end
 
 SMH.GhostsManager = MGR

--- a/lua/smh/server/ghosts_manager.lua
+++ b/lua/smh/server/ghosts_manager.lua
@@ -93,7 +93,7 @@ function MGR.UpdateState(player, frame, settings)
                 local g = CreateGhost(entity, Color(200, 0, 0, alpha))
                 table.insert(ghosts, g)
                 SetGhostFrame(entity, g, prevKeyframe.Modifiers)
-            elseif settings.GhostNextFrame and prevKeyframe.Frame > frame then
+            elseif settings.GhostNextFrame and nextKeyframe.Frame > frame then
                 local g = CreateGhost(entity, Color(0, 200, 0, alpha))
                 table.insert(ghosts, g)
                 SetGhostFrame(entity, g, prevKeyframe.Modifiers)

--- a/lua/smh/server/keyframe_manager.lua
+++ b/lua/smh/server/keyframe_manager.lua
@@ -117,7 +117,8 @@ end
 
 function MGR.ImportSave(player, entity, serializedKeyframes)
     if SMH.KeyframeData.Players[player] and SMH.KeyframeData.Players[player].Entities[entity] then
-        for _, keyframe in pairs(SMH.KeyframeData.Players[player].Entities[entity]) do
+		local deletethis = table.Copy(SMH.KeyframeData.Players[player].Entities[entity])
+        for _, keyframe in pairs(deletethis) do
             SMH.KeyframeData:Delete(player, keyframe.ID)
         end
     end

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -56,11 +56,11 @@ hook.Add("Think", "SMHPlaybackManagerThink", function()
         playback.Timer = playback.Timer + FrameTime()
         local timePerFrame = 1 / playback.PlaybackRate
         if playback.Timer >= timePerFrame then
-            playback.CurrentFrame = playback.CurrentFrame + 1
+            playback.CurrentFrame = math.floor(playback.Timer / timePerFrame)
             if playback.CurrentFrame > playback.EndFrame then
                 playback.CurrentFrame = playback.StartFrame
+				playback.Timer = 0
             end
-            playback.Timer = 0
             MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
         end
     end

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -56,9 +56,10 @@ hook.Add("Think", "SMHPlaybackManagerThink", function()
         playback.Timer = playback.Timer + FrameTime()
         local timePerFrame = 1 / playback.PlaybackRate
         if playback.Timer >= timePerFrame then
-            playback.CurrentFrame = math.floor(playback.Timer / timePerFrame)
+            playback.CurrentFrame = math.floor(playback.Timer / timePerFrame) + playback.StartFrame
             if playback.CurrentFrame > playback.EndFrame then
-                playback.CurrentFrame = playback.StartFrame
+                playback.CurrentFrame = 0
+				playback.StartFrame = 0
 				playback.Timer = 0
             end
             MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)

--- a/lua/smh/shared.lua
+++ b/lua/smh/shared.lua
@@ -20,6 +20,7 @@ SMH.MessageTypes = {
     "StopPlayback",
     "PlaybackResponse",
 
+	"IsRendering",
     "UpdateGhostState",
     "UpdateGhostStateResponse",
 


### PR DESCRIPTION
Changes
- Loading save onto an entity will fully cleanup that entity's keyframes
- Fixed playback speed
- Ghosts get updated just as you enable their setting
- Ghosts get disabled during render process
- Render process doesn't throw errors, goes from frame 0 to PlayBackLength - 1
- Loading should remember last save file you've picked, so there's no need to select it all over again during load
- Dragging and dropping keyframe onto another one will delete another keyframe
- Copying a keyframe and not moving it anywhere won't move it to frame 0
- Deleting selected entities now will clear keyframes in the UI