### PR TITLE
Properties update - multiple timelines per entity support

### DIFF
--- a/lua/smh/client/concommands.lua
+++ b/lua/smh/client/concommands.lua
@@ -45,3 +45,7 @@ end)
 concommand.Add("smh_makescreenshot", function()
     SMH.Controller.ToggleRendering(true)
 end)
+
+concommand.Add("smh_savepreset", function()
+    SMH.Controller.SaveProperties()
+end)

--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -1,5 +1,26 @@
 local INT_BITCOUNT = 32
 
+local function ReceiveKeyframes()
+    local entity = net.ReadEntity()
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    return SMH.TableSplit.GetKeyframes(), entity
+end
+
+local function ReceiveProperties()
+    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+    for i=1, Timelines do
+        net.ReadUInt(4)
+        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+        for j=1, net.ReadUInt(INT_BITCOUNT) do
+            SMH.TableSplit.AProperties(i, net.ReadString())
+        end
+    end
+    return SMH.TableSplit.GetProperties()
+end
+
 local CTRL = {}
 
 function CTRL.SetFrame(frame)
@@ -257,25 +278,11 @@ local function SetFrameResponse(msgLength)
 end
 
 local function SelectEntityResponse(msgLength)
-    local entity = net.ReadEntity()
+    local keyframes, entity = ReceiveKeyframes()
     local timeline = {}
 
-    local framecount = net.ReadUInt(INT_BITCOUNT)
-    for i = 1, framecount do
-        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
-    end
-    local keyframes = SMH.TableSplit.GetKeyframes()
-
     if net.ReadBool() then
-        local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
-        for i=1, Timelines do
-            net.ReadUInt(4)
-            SMH.TableSplit.AProperties(i, nil, net.ReadColor())
-            for j=1, net.ReadUInt(INT_BITCOUNT) do
-                SMH.TableSplit.AProperties(i, net.ReadString())
-            end
-        end
-        timeline = SMH.TableSplit.GetProperties()
+        timeline = ReceiveProperties()
     end
 
     SMH.State.Entity = entity
@@ -284,13 +291,7 @@ local function SelectEntityResponse(msgLength)
 end
 
 local function UpdateKeyframeResponse(msgLength)
-    local entity = net.ReadEntity()
-
-    local framecount = net.ReadUInt(INT_BITCOUNT)
-    for i = 1, framecount do
-        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
-    end
-    local keyframes = SMH.TableSplit.GetKeyframes()
+    local keyframes = ReceiveKeyframes()
 
     for num, keyframe in ipairs(keyframes) do
         if keyframe.Entity == SMH.State.Entity then
@@ -299,15 +300,8 @@ local function UpdateKeyframeResponse(msgLength)
     end
 
     if net.ReadBool() then
-        local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
-        for i=1, Timelines do
-            net.ReadUInt(4)
-            SMH.TableSplit.AProperties(i, nil, net.ReadColor())
-            for j=1, net.ReadUInt(INT_BITCOUNT) do
-                SMH.TableSplit.AProperties(i, net.ReadString())
-            end
-        end
-        SMH.UI.SetTimeline(SMH.TableSplit.GetProperties())
+        local timeline = ReceiveProperties()
+        SMH.UI.SetTimeline(timeline)
     end
 end
 
@@ -346,23 +340,8 @@ local function GetServerEntitiesResponse(msgLength)
 end
 
 local function LoadResponse(msgLength)
-    local entity = net.ReadEntity()
-
-    local framecount = net.ReadUInt(INT_BITCOUNT)
-    for i = 1, framecount do
-        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
-    end
-    local keyframes = SMH.TableSplit.GetKeyframes()
-
-    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
-    for i=1, Timelines do
-        net.ReadUInt(4)
-        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
-        for j=1, net.ReadUInt(INT_BITCOUNT) do
-            SMH.TableSplit.AProperties(i, net.ReadString())
-        end
-    end
-    local timeline = SMH.TableSplit.GetProperties()
+    local keyframes, entity = ReceiveKeyframes()
+    local timeline = ReceiveProperties()
 
     if entity == SMH.State.Entity then
         SMH.UI.SetTimeline(timeline)
@@ -401,13 +380,7 @@ local function ApplyEntityNameResponse(msgLength)
 end
 
 local function UpdateTimelineResponse(msgLength)
-    local entity = net.ReadEntity()
-
-    local framecount = net.ReadUInt(INT_BITCOUNT)
-    for i = 1, framecount do
-        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
-    end
-    local keyframes = SMH.TableSplit.GetKeyframes()
+    local keyframes = ReceiveKeyframes()
 
     SMH.UI.SetKeyframes(keyframes)
 end
@@ -419,23 +392,8 @@ local function RequestModifiersResponse(msgLength)
 end
 
 local function UpdateTimelineInfoResponse(msgLength)
-    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
-    for i=1, Timelines do
-        net.ReadUInt(4)
-        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
-        for j=1, net.ReadUInt(INT_BITCOUNT) do
-            SMH.TableSplit.AProperties(i, net.ReadString())
-        end
-    end
-    local timeline = SMH.TableSplit.GetProperties()
-
-    local entity = net.ReadEntity()
-
-    local framecount = net.ReadUInt(INT_BITCOUNT)
-    for i = 1, framecount do
-        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
-    end
-    local keyframes = SMH.TableSplit.GetKeyframes()
+    local timeline = ReceiveProperties()
+    local keyframes = ReceiveKeyframes()
 
     SMH.UI.SetTimeline(timeline)
     SMH.UI.SetKeyframes(keyframes)
@@ -443,39 +401,15 @@ end
 
 local function UpdateModifierResponse(msgLength)
     local changed = net.ReadString()
-    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
-        for i=1, Timelines do
-            net.ReadUInt(4)
-            SMH.TableSplit.AProperties(i, nil, net.ReadColor())
-            for j=1, net.ReadUInt(INT_BITCOUNT) do
-                SMH.TableSplit.AProperties(i, net.ReadString())
-            end
-        end
-    local timeline = SMH.TableSplit.GetProperties()
-
-    local entity = net.ReadEntity()
-
-    local framecount = net.ReadUInt(INT_BITCOUNT)
-    for i = 1, framecount do
-        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
-    end
-    local keyframes = SMH.TableSplit.GetKeyframes()
-
+    local timeline = ReceiveProperties()
+    local keyframes = ReceiveKeyframes()
 
     SMH.UI.UpdateModifier(timeline, changed)
     SMH.UI.SetKeyframes(keyframes)
 end
 
 local function UpdateKeyframeColorResponse(msgLength)
-    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
-    for i=1, Timelines do
-        net.ReadUInt(4)
-        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
-        for j=1, net.ReadUInt(INT_BITCOUNT) do
-            SMH.TableSplit.AProperties(i, net.ReadString())
-            end
-    end
-    local timelineinfo = SMH.TableSplit.GetProperties()
+    local timelineinfo = ReceiveProperties()
 
     SMH.UI.UpdateKeyColor(timelineinfo)
 end

--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -258,8 +258,25 @@ end
 
 local function SelectEntityResponse(msgLength)
     local entity = net.ReadEntity()
-    local keyframes = net.ReadTable()
-    local timeline = net.ReadTable()
+    local timeline = {}
+
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    local keyframes = SMH.TableSplit.GetKeyframes()
+
+    if net.ReadBool() then
+        local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+        for i=1, Timelines do
+            net.ReadUInt(4)
+            SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+            for j=1, net.ReadUInt(INT_BITCOUNT) do
+                SMH.TableSplit.AProperties(i, net.ReadString())
+            end
+        end
+        timeline = SMH.TableSplit.GetProperties()
+    end
 
     SMH.State.Entity = entity
     SMH.UI.SetTimeline(timeline)
@@ -267,19 +284,30 @@ local function SelectEntityResponse(msgLength)
 end
 
 local function UpdateKeyframeResponse(msgLength)
-    local keyframeIds = net.ReadTable()
-    local keyframes = net.ReadTable()
+    local entity = net.ReadEntity()
+
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    local keyframes = SMH.TableSplit.GetKeyframes()
 
     for num, keyframe in ipairs(keyframes) do
-        keyframe.ID = keyframeIds[num]
-
         if keyframe.Entity == SMH.State.Entity then
             SMH.UI.UpdateKeyframe(keyframe)
         end
     end
 
     if net.ReadBool() then
-        SMH.UI.SetTimeline(net.ReadTable())
+        local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+        for i=1, Timelines do
+            net.ReadUInt(4)
+            SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+            for j=1, net.ReadUInt(INT_BITCOUNT) do
+                SMH.TableSplit.AProperties(i, net.ReadString())
+            end
+        end
+        SMH.UI.SetTimeline(SMH.TableSplit.GetProperties())
     end
 end
 
@@ -293,25 +321,48 @@ local function DeleteKeyframeResponse(msgLength)
 end
 
 local function GetServerSavesResponse(msgLength)
-    local saves = net.ReadTable()
+    for i=1, net.ReadUInt(INT_BITCOUNT) do
+        SMH.TableSplit.AList(net.ReadString(), net.ReadString())
+    end
+    local saves = SMH.TableSplit.GetList()
     SMH.UI.SetServerSaves(saves)
 end
 
 local function GetModelListResponse(msgLength)
-    local models = net.ReadTable()
+    for i=1, net.ReadUInt(INT_BITCOUNT) do
+        SMH.TableSplit.AList(net.ReadString(), net.ReadString())
+    end
+    local models = SMH.TableSplit.GetList()
     local map = net.ReadString()
     SMH.UI.SetModelList(models, map)
 end
 
 local function GetServerEntitiesResponse(msgLength)
-    local entities = net.ReadTable()
+    for i=1, net.ReadUInt(INT_BITCOUNT) do
+        SMH.TableSplit.AList(net.ReadEntity(), {Name = net.ReadString()})
+    end
+    local entities = SMH.TableSplit.GetList()
     SMH.UI.SetEntityList(entities)
 end
 
 local function LoadResponse(msgLength)
     local entity = net.ReadEntity()
-    local keyframes = net.ReadTable()
-    local timeline = net.ReadTable()
+
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    local keyframes = SMH.TableSplit.GetKeyframes()
+
+    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+    for i=1, Timelines do
+        net.ReadUInt(4)
+        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+        for j=1, net.ReadUInt(INT_BITCOUNT) do
+            SMH.TableSplit.AProperties(i, net.ReadString())
+        end
+    end
+    local timeline = SMH.TableSplit.GetProperties()
 
     if entity == SMH.State.Entity then
         SMH.UI.SetTimeline(timeline)
@@ -350,7 +401,13 @@ local function ApplyEntityNameResponse(msgLength)
 end
 
 local function UpdateTimelineResponse(msgLength)
-    local keyframes = net.ReadTable()
+    local entity = net.ReadEntity()
+
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    local keyframes = SMH.TableSplit.GetKeyframes()
 
     SMH.UI.SetKeyframes(keyframes)
 end
@@ -362,8 +419,23 @@ local function RequestModifiersResponse(msgLength)
 end
 
 local function UpdateTimelineInfoResponse(msgLength)
-    local timeline = net.ReadTable()
-    local keyframes = net.ReadTable()
+    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+    for i=1, Timelines do
+        net.ReadUInt(4)
+        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+        for j=1, net.ReadUInt(INT_BITCOUNT) do
+            SMH.TableSplit.AProperties(i, net.ReadString())
+        end
+    end
+    local timeline = SMH.TableSplit.GetProperties()
+
+    local entity = net.ReadEntity()
+
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    local keyframes = SMH.TableSplit.GetKeyframes()
 
     SMH.UI.SetTimeline(timeline)
     SMH.UI.SetKeyframes(keyframes)
@@ -371,15 +443,39 @@ end
 
 local function UpdateModifierResponse(msgLength)
     local changed = net.ReadString()
-    local timeline = net.ReadTable()
-    local keyframes = net.ReadTable()
+    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+        for i=1, Timelines do
+            net.ReadUInt(4)
+            SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+            for j=1, net.ReadUInt(INT_BITCOUNT) do
+                SMH.TableSplit.AProperties(i, net.ReadString())
+            end
+        end
+    local timeline = SMH.TableSplit.GetProperties()
+
+    local entity = net.ReadEntity()
+
+    local framecount = net.ReadUInt(INT_BITCOUNT)
+    for i = 1, framecount do
+        SMH.TableSplit.AKeyframes(net.ReadUInt(INT_BITCOUNT), entity, net.ReadUInt(INT_BITCOUNT), net.ReadFloat(), net.ReadFloat(), nil, net.ReadString())
+    end
+    local keyframes = SMH.TableSplit.GetKeyframes()
+
 
     SMH.UI.UpdateModifier(timeline, changed)
     SMH.UI.SetKeyframes(keyframes)
 end
 
 local function UpdateKeyframeColorResponse(msgLength)
-    local timelineinfo = net.ReadTable()
+    local Timelines = SMH.TableSplit.StartAProperties(net.ReadString(), net.ReadUInt(INT_BITCOUNT))
+    for i=1, Timelines do
+        net.ReadUInt(4)
+        SMH.TableSplit.AProperties(i, nil, net.ReadColor())
+        for j=1, net.ReadUInt(INT_BITCOUNT) do
+            SMH.TableSplit.AProperties(i, net.ReadString())
+            end
+    end
+    local timelineinfo = SMH.TableSplit.GetProperties()
 
     SMH.UI.UpdateKeyColor(timelineinfo)
 end

--- a/lua/smh/client/derma/frame_pointer.lua
+++ b/lua/smh/client/derma/frame_pointer.lua
@@ -24,6 +24,7 @@ function PANEL:Init()
 
     self._frame = 0
     self._dragging = false
+    self._mod = "nil"
 
 end
 
@@ -93,6 +94,14 @@ function PANEL:IsDragging()
     return self._dragging
 end
 
+function PANEL:GetMod()
+    return self._mod
+end
+
+function PANEL:SetMod(mod)
+    self._mod = mod
+end
+
 function PANEL:OnMousePressed(mousecode)
     if mousecode ~= MOUSE_LEFT then
         self:OnCustomMousePressed(mousecode)
@@ -101,6 +110,8 @@ function PANEL:OnMousePressed(mousecode)
 
     self:MouseCapture(true)
     self._dragging = true
+
+    SMH.UI.AssignFrames(self)
 
     local parent = self:GetParent() -- this is the part from OnCursorMoved(), mostly needed to the cases when we copy and paste a frame on top of itself, as by default it seems to go back to frame 0
 
@@ -115,7 +126,20 @@ function PANEL:OnMousePressed(mousecode)
 
     if targetPos ~= self._frame then
         self:SetFrame(targetPos)
+        SMH.UI.MoveChildren(self, targetPos)
     end
+end
+
+function PANEL:SetParentPointer(ppointer)
+    self.parent = ppointer
+end
+
+function PANEL:ClearParentPointer()
+    self.parent = nil
+end
+
+function PANEL:GetParentKeyframe()
+    return self.parent
 end
 
 function PANEL:OnMouseReleased(mousecode)
@@ -125,6 +149,7 @@ function PANEL:OnMouseReleased(mousecode)
 
     self:MouseCapture(false)
     self._dragging = false
+    SMH.UI.ClearFrames(self)
     self:OnPointerReleased(self._frame)
 end
 
@@ -147,6 +172,7 @@ function PANEL:OnCursorMoved()
     if targetPos ~= self._frame then
         self:SetFrame(targetPos)
         self:OnFrameChanged(targetPos)
+        SMH.UI.MoveChildren(self, targetPos)
     end
 end
 

--- a/lua/smh/client/derma/properties.lua
+++ b/lua/smh/client/derma/properties.lua
@@ -9,7 +9,7 @@ local function GetModelName(entity)
     return mdl
 end
 
-local function FindEntity(entity)
+local function FindEntityInfo(entity)
     if EntsTable then
         for kentity, value in pairs(EntsTable) do
             if kentity == entity then
@@ -21,19 +21,41 @@ local function FindEntity(entity)
     return nil
 end
 
+local function FindEntity(name)
+    if EntsTable then
+        for kentity, value in pairs(EntsTable) do
+            if value.Name == name then
+                return kentity
+            end
+        end
+    end
+
+    return nil
+end
+
+local function UpdateName(name)
+    if not IsValid(selectedEntity) then return end
+    if EntsTable then
+        EntsTable[selectedEntity].Name = name
+    end
+end
+
 function PANEL:Init()
 
     self:SetTitle("Properties")
     self:SetDeleteOnClose(false)
     self:SetSizable(true)
 
-    self:SetSize(250, 210)
-    self:SetMinWidth(250)
-    self:SetMinHeight(210)
+    self:SetSize(500, 420)
+    self:SetMinWidth(500)
+    self:SetMinHeight(420)
     self:SetPos(ScrW() / 2 - self:GetWide() / 2, ScrH() / 2 - self:GetTall() / 2)
 
-    self.EntityNameEnter = vgui.Create("DTextEntry", self)
-    self.EntityNameEnter:SetSize(240, 20)
+    self.EntitiesPanel = vgui.Create("DPanel", self)
+    self.EntitiesPanel:SetBackgroundColor(Color(155, 155, 155, 255))
+
+    self.EntityNameEnter = vgui.Create("DTextEntry", self.EntitiesPanel)
+    self.EntityNameEnter:SetSize(236, 20)
     self.EntityNameEnter:SetEditable(false)
     self.EntityNameEnter:SetText("none")
     self.EntityNameEnter.OnLoseFocus = function(sel)
@@ -43,9 +65,20 @@ function PANEL:Init()
 
         self:ApplyName(selectedEntity, sel:GetValue())
     end
-        self.EntityNameEnter.Label = vgui.Create("DLabel", self)
+        self.EntityNameEnter.Label = vgui.Create("DLabel", self.EntitiesPanel)
         self.EntityNameEnter.Label:SetText("Selected entity's name:")
         self.EntityNameEnter.Label:SizeToContents()
+
+    self.EntityList = vgui.Create("DListView", self.EntitiesPanel)
+    self.EntityList:AddColumn("Recorded Entities")
+    self.EntityList:SetMultiSelect(false)
+    self.EntityList.OnRowSelected = function(_, rowIndex, row)
+        local _, selectedName = self.EntityList:GetSelectedLine()
+        if not IsValid(selectedName) then return end
+        local selectedEntity = FindEntity(selectedName:GetValue(1))
+        if not IsValid(selectedEntity) then return end
+        self:SelectEntity(selectedEntity)
+    end
 
 end
 
@@ -53,27 +86,37 @@ function PANEL:PerformLayout(width, height)
 
     self.BaseClass.PerformLayout(self, width, height)
 
-    self.EntityNameEnter:Center()
-        self.EntityNameEnter.Label:SetRelativePos(self.EntityNameEnter, 0, -5 - self.EntityNameEnter.Label:GetTall())
+	self.EntitiesPanel:SetPos(4, 30)
+    self.EntitiesPanel:SetSize(240, self:GetTall() - 4 - 30)
+
+    self.EntityNameEnter:SetPos(2, 25)
+        self.EntityNameEnter.Label:SetRelativePos(self.EntityNameEnter, 2, -5 - self.EntityNameEnter.Label:GetTall())
+
+    self.EntityList:SetPos(5, 60)
+    self.EntityList:SetSize(230, self.EntitiesPanel:GetTall() - 60 - 5)
 
 end
 
 function PANEL:UpdateSelectedEnt(ent)
     selectedEntity = ent
+    self:SetEntities(EntsTable)
 end
 
 function PANEL:SetName(name)
     self.EntityNameEnter:SetText(name)
+    UpdateName(name)
+    self:SetEntities(EntsTable)
 end
 
 function PANEL:SetEntities(entities)
+    local entlist = {}
     EntsTable = table.Copy(entities)
 
     if not IsValid(selectedEntity) then
         self.EntityNameEnter:SetText("none")
         self.EntityNameEnter:SetEditable(false)
     else
-        local entityinfo = FindEntity(selectedEntity)
+        local entityinfo = FindEntityInfo(selectedEntity)
 
         if not entityinfo then
             Fallback = GetModelName(selectedEntity)
@@ -85,8 +128,15 @@ function PANEL:SetEntities(entities)
             self.EntityNameEnter:SetEditable(true)
         end
     end
+
+    for entity, value in pairs(EntsTable) do
+        table.insert(entlist, value.Name)
+    end
+
+    self.EntityList:UpdateLines(entlist)
 end
 
 function PANEL:ApplyName(ent, name) end
+function PANEL:SelectEntity(entity) end
 
 vgui.Register("SMHProperties", PANEL, "DFrame")

--- a/lua/smh/client/derma/smh_menu.lua
+++ b/lua/smh/client/derma/smh_menu.lua
@@ -3,7 +3,7 @@ local PANEL = {}
 function PANEL:Init()
 
     self:SetTitle("Stop Motion Helper")
-    self:SetSize(ScrW(), 75)
+    self:SetSize(ScrW(), 90)
     self:SetPos(0, ScrH() - self:GetTall())
     self:SetDraggable(false)
     self:ShowCloseButton(false)
@@ -15,6 +15,8 @@ function PANEL:Init()
     self.FramePanel = vgui.Create("SMHFramePanel", self)
 
     self.FramePointer = self.FramePanel:CreateFramePointer(Color(255, 255, 255), self.FramePanel:GetTall() / 4, true)
+
+    self.TimelinesBase = vgui.Create("Panel", self)
 
     self.PositionLabel = vgui.Create("DLabel", self)
 
@@ -96,10 +98,13 @@ function PANEL:PerformLayout(width, height)
 
     self:SetTitle("Stop Motion Helper")
 
-    self.FramePanel:SetPos(5, 25)
+    self.FramePanel:SetPos(5, 40)
     self.FramePanel:SetSize(width - 5 * 2, 45)
 
     self.FramePointer.VerticalPosition = self.FramePanel:GetTall() / 4
+
+    self.TimelinesBase:SetPos(0, 25)
+    self.TimelinesBase:SetSize(ScrW(),15)
 
     self.PositionLabel:SetPos(150, 5)
 
@@ -141,6 +146,48 @@ function PANEL:PerformLayout(width, height)
     self.SettingsButton:SetPos(width - 60 * 1 - 5 * 1, 2)
     self.SettingsButton:SetSize(60, 20)
 
+end
+
+function PANEL:UpdateTimelines(timelineinfo)
+    self.TimelinesBase:Clear()
+
+    if next(timelineinfo) == nil then return end --check if supplied table is empty
+    local TotallTimelines = timelineinfo.Timelines
+    if TotallTimelines < SMH.State.Timeline then SMH.State.Timeline = 1 end
+    self.TimelinesBase.Timeline = {}
+
+    for i = 1, TotallTimelines do
+        self.TimelinesBase.Timeline[i] = vgui.Create("DPanel", self.TimelinesBase)
+        self.TimelinesBase.Timeline[i]:SetPos((i - 1) * (ScrW() / TotallTimelines) + 4,0)
+        self.TimelinesBase.Timeline[i]:SetSize((ScrW() / TotallTimelines) - 8,15)
+        if i == SMH.State.Timeline then
+            self.TimelinesBase.Timeline[i]:SetBackgroundColor(Color(220, 220, 220, 255))
+        else
+            self.TimelinesBase.Timeline[i]:SetBackgroundColor(Color(175, 175, 175, 255))
+        end
+
+        self.TimelinesBase.Timeline[i].Label = vgui.Create("DLabel", self.TimelinesBase.Timeline[i])
+        self.TimelinesBase.Timeline[i].Label:SetText("Timeline " .. i)
+        self.TimelinesBase.Timeline[i].Label:SetTextColor(Color(100, 100, 100))
+        self.TimelinesBase.Timeline[i].Label:SizeToContents()
+        self.TimelinesBase.Timeline[i].Label:Center()
+
+        self.TimelinesBase.Timeline[i]._pressed = false
+        self.TimelinesBase.Timeline[i].OnMousePressed = function(_, mousecode)
+            if mousecode ~= MOUSE_LEFT then return end
+
+            SMH.State.Timeline = i
+            SMH.Controller.UpdateTimeline()
+
+            for j = 1, TotallTimelines do
+                if j ~= i then
+                    self.TimelinesBase.Timeline[j]:SetBackgroundColor(Color(175, 175, 175, 255))
+                else
+                    self.TimelinesBase.Timeline[j]:SetBackgroundColor(Color(220, 220, 220, 255))
+                end
+            end
+        end
+    end
 end
 
 function PANEL:SetInitialState(state)

--- a/lua/smh/client/state.lua
+++ b/lua/smh/client/state.lua
@@ -1,6 +1,7 @@
 SMH.State = {
     Entity = nil,
     Frame = 0,
+    Timeline = 1,
 
     PlaybackRate = 30,
     PlaybackLength = 100,

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -6,48 +6,69 @@ local PropertiesMenu = nil
 local FrameToKeyframe = {}
 local KeyframePointers = {}
 local KeyframeEasingData = {}
+local LastID = 0
 local ClickerEntity = nil
+local KeyColor = Color(0, 200, 0)
 
-local function CreateCopyPointer(keyframeId)
+local function CreateCopyPointer(keyframeId, mods)
     local pointer = WorldClicker.MainMenu.FramePanel:CreateFramePointer(
-        Color(0, 200, 0),
+        KeyColor,
         WorldClicker.MainMenu.FramePanel:GetTall() / 4 * 2.2,
         false
     )
     pointer:OnMousePressed(MOUSE_LEFT)
     pointer.OnPointerReleased = function(_, frame)
-        SMH.Controller.CopyKeyframe(keyframeId, frame)
         WorldClicker.MainMenu.FramePanel:DeleteFramePointer(pointer)
-        for id, pointer in pairs(KeyframePointers) do
-            if id == keyframeId + 1 then continue end
-            if pointer:GetFrame() == frame then
-                SMH.Controller.DeleteKeyframe(id)
+        local counter = 1
+        for mod, idm in pairs(mods) do
+            SMH.Controller.CopyKeyframe(idm, frame)
+
+            for id, pointer in pairs(KeyframePointers) do
+                if id == LastID + counter then continue end
+                if pointer:GetFrame() == frame and mod == pointer:GetMod() then
+                    SMH.Controller.DeleteKeyframe(id)
+                end
             end
+            counter = counter + 1
         end
     end
 end
 
-local function NewKeyframePointer(keyframeId)
+local function NewKeyframePointer(keyframeId, modname)
+    if keyframeId > LastID then LastID = keyframeId end
+
     local pointer = WorldClicker.MainMenu.FramePanel:CreateFramePointer(
-        Color(0, 200, 0),
+        KeyColor,
         WorldClicker.MainMenu.FramePanel:GetTall() / 4 * 2.2,
         false
     )
+    pointer:SetMod(modname)
 
     pointer.OnPointerReleased = function(_, frame)
         SMH.Controller.UpdateKeyframe(keyframeId, { Frame = frame })
         for id, pointer in pairs(KeyframePointers) do
             if id == keyframeId then continue end
-            if pointer:GetFrame() == frame then
+            if pointer:GetFrame() == frame and pointer:GetMod() == modname then
                 SMH.Controller.DeleteKeyframe(id)
             end
         end
     end
     pointer.OnCustomMousePressed = function(_, mousecode)
+        local frame = pointer:GetFrame()
         if mousecode == MOUSE_RIGHT and not input.IsKeyDown(KEY_LCONTROL) then
-            SMH.Controller.DeleteKeyframe(keyframeId)
+            for id, kpointer in pairs(KeyframePointers) do
+                if kpointer:GetFrame() == frame then
+                    SMH.Controller.DeleteKeyframe(id)
+                end
+            end
         elseif mousecode == MOUSE_MIDDLE or (mousecode == MOUSE_RIGHT and input.IsKeyDown(KEY_LCONTROL)) then
-            CreateCopyPointer(keyframeId)
+            local mods = {}
+            for id, kpointer in pairs(KeyframePointers) do
+                if kpointer:GetFrame() == frame then
+                    mods[kpointer:GetMod()] = id
+                end
+            end
+            CreateCopyPointer(keyframeId, mods)
         end
     end
 
@@ -147,6 +168,22 @@ local function AddCallbacks()
         ClickerEntity = ent
     end
 
+    PropertiesMenu.OnAddTimelineRequested = function()
+        SMH.Controller.AddTimeline()
+    end
+    
+    PropertiesMenu.OnRemoveTimelineRequested = function()
+        SMH.Controller.RemoveTimeline()
+    end
+
+    PropertiesMenu.OnUpdateModifierRequested = function(_, i, mod, check)
+        SMH.Controller.UpdateModifier(i, mod, check)
+    end
+
+    PropertiesMenu.OnUpdateKeyframeColorRequested = function(_, color, timeline)
+        SMH.Controller.UpdateKeyframeColor(color, timeline)
+    end
+
 end
 
 hook.Add("EntityRemoved", "SMHWorldClickerEntityRemoved", function(entity)
@@ -164,7 +201,7 @@ hook.Add("InitPostEntity", "SMHMenuSetup", function()
     WorldClicker.MainMenu = vgui.Create("SMHMenu", WorldClicker)
 
     WorldClicker.Settings = vgui.Create("SMHSettings", WorldClicker)
-    WorldClicker.Settings:SetPos(ScrW() - 250, ScrH() - 75 - 225)
+    WorldClicker.Settings:SetPos(ScrW() - 250, ScrH() - 90 - 225)
     WorldClicker.Settings:SetVisible(false)
 
     SaveMenu = vgui.Create("SMHSave")
@@ -180,6 +217,8 @@ hook.Add("InitPostEntity", "SMHMenuSetup", function()
     PropertiesMenu:SetVisible(false)
 
     AddCallbacks()
+
+    SMH.Controller.RequestModifiers() -- needed to initialize properties menu
 
     WorldClicker.MainMenu:SetInitialState(SMH.State)
 
@@ -222,17 +261,32 @@ function MGR.SetKeyframes(keyframes)
     for _, pointer in pairs(KeyframePointers) do
         WorldClicker.MainMenu.FramePanel:DeleteFramePointer(pointer)
     end
+
+    local propertymods = PropertiesMenu:GetCurrentModifiers()
+
+    if not propertymods.KeyColor then
+        KeyColor = Color(0, 200, 0)
+    else
+        KeyColor = propertymods.KeyColor
+    end
+
+    local Modifiers = {}
+    for _, name in ipairs(propertymods) do
+        Modifiers[name] = true
+    end
     KeyframePointers = {}
     FrameToKeyframe = {}
 
     for _, keyframe in pairs(keyframes) do
-        KeyframePointers[keyframe.ID] = NewKeyframePointer(keyframe.ID)
-        KeyframePointers[keyframe.ID]:SetFrame(keyframe.Frame)
-        FrameToKeyframe[keyframe.Frame] = keyframe.ID
-        KeyframeEasingData[keyframe.ID] = {
-            EaseIn = keyframe.EaseIn,
-            EaseOut = keyframe.EaseOut,
-        }
+        if Modifiers[keyframe.Modifier] then
+            KeyframePointers[keyframe.ID] = NewKeyframePointer(keyframe.ID, keyframe.Modifier)
+            KeyframePointers[keyframe.ID]:SetFrame(keyframe.Frame)
+            FrameToKeyframe[keyframe.Frame] = keyframe.ID
+            KeyframeEasingData[keyframe.ID] = {
+                EaseIn = keyframe.EaseIn,
+                EaseOut = keyframe.EaseOut,
+            }
+        end
     end
 end
 
@@ -243,7 +297,7 @@ function MGR.UpdateKeyframe(keyframe)
     }
 
     if not KeyframePointers[keyframe.ID] then
-        KeyframePointers[keyframe.ID] = NewKeyframePointer(keyframe.ID)
+        KeyframePointers[keyframe.ID] = NewKeyframePointer(keyframe.ID, keyframe.Modifier)
 
         -- TODO should this logic exist? Where should it be?
         -- if FrameToKeyframe[keyframe.Frame] and KeyframePointers[FrameToKeyframe[keyframe.Frame]] then
@@ -281,6 +335,43 @@ function MGR.DeleteKeyframe(keyframeId)
     end
 end
 
+function MGR.AssignFrames(pointer)
+    local frame = pointer:GetFrame()
+    local keyID
+    for id, kpointer in pairs(KeyframePointers) do
+        if pointer == kpointer then
+            keyID = id
+            break
+        end
+    end
+
+    if not keyID then return end
+
+    for id, kpointer in pairs(KeyframePointers) do
+        if keyID == id then continue end
+        if kpointer:GetFrame() == frame then
+            kpointer:SetParentPointer(pointer)
+        end
+    end
+end
+
+function MGR.MoveChildren(pointer, frame)
+    for id, kpointer in pairs(KeyframePointers) do
+        if kpointer:GetParentKeyframe() == pointer then
+            kpointer:SetFrame(frame)
+        end
+    end
+end
+
+function MGR.ClearFrames(pointer)
+    for id, kpointer in pairs(KeyframePointers) do
+        if kpointer:GetParentKeyframe() == pointer then
+            kpointer:OnPointerReleased(kpointer:GetFrame())
+            kpointer:ClearParentPointer()
+        end
+    end
+end
+
 function MGR.SetServerSaves(saves)
     LoadMenu:SetSaves(saves)
     SaveMenu:SetSaves(saves)
@@ -310,9 +401,38 @@ function MGR.RemoveSaveFile(path)
     SaveMenu:RemoveSave(path)
 end
 
+function MGR.InitModifiers(list)
+    PropertiesMenu:InitModifiers(list)
+end
+
+function MGR.SetTimeline(timeline)
+    WorldClicker.MainMenu:UpdateTimelines(timeline)
+    PropertiesMenu:UpdateTimelineInfo(timeline)
+end
+
 function MGR.UpdateState(newState)
     WorldClicker.MainMenu:UpdatePositionLabel(newState.Frame, newState.PlaybackLength)
     WorldClicker.MainMenu.FramePanel:UpdateFrameCount(newState.PlaybackLength)
+end
+
+function MGR.UpdateModifier(timelineinfo, changed)
+    PropertiesMenu:UpdateModifiersInfo(timelineinfo, changed)
+end
+
+function MGR.UpdateKeyColor(timelineinfo)
+    PropertiesMenu:UpdateColor(timelineinfo)
+end
+
+function MGR.PaintKeyframes(color)
+    KeyColor = color
+
+    for _, pointer in pairs(KeyframePointers) do
+        pointer.Color = KeyColor
+    end
+end
+
+function MGR.GetModifiers()
+    return PropertiesMenu:GetModifiers()
 end
 
 SMH.UI = MGR

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -88,8 +88,10 @@ local function AddCallbacks()
         SMH.Controller.UpdateState(newState)
     end
     WorldClicker.MainMenu.OnRequestKeyframeUpdate = function(_, newKeyframeData)
-        if FrameToKeyframe[SMH.State.Frame] then
-            SMH.Controller.UpdateKeyframe(FrameToKeyframe[SMH.State.Frame], newKeyframeData)
+        for id, pointer in pairs(KeyframePointers) do
+            if pointer:GetFrame() == SMH.State.Frame then
+                SMH.Controller.UpdateKeyframe(id, newKeyframeData)
+            end
         end
     end
     WorldClicker.MainMenu.OnRequestOpenPropertiesMenu = function()

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -140,6 +140,13 @@ local function AddCallbacks()
         SMH.Controller.ApplyEntityName(ent, name)
     end
 
+    PropertiesMenu.SelectEntity = function(_, ent)
+        SMH.Controller.SelectEntity(ent)
+        LoadMenu:UpdateSelectedEnt(ent)
+        PropertiesMenu:UpdateSelectedEnt(ent)
+        ClickerEntity = ent
+    end
+
 end
 
 hook.Add("EntityRemoved", "SMHWorldClickerEntityRemoved", function(entity)

--- a/lua/smh/modifiers/advlights.lua
+++ b/lua/smh/modifiers/advlights.lua
@@ -40,11 +40,16 @@ function MOD:Save(entity)
         local theclass = entity:GetClass();
         if theclass ~= "expensive_light" and theclass ~= "expensive_light_new" then -- expensive lights don't have FoV settings, but they are projected lights
             data.FOV = entity:GetLightFOV();
-            end
+        end
+        if theclass == "projected_light_new" then
+            data.OrthoBottom = entity:GetOrthoBottom();
+            data.OrthoLeft = entity:GetOrthoLeft();
+            data.OrthoRight = entity:GetOrthoRight();
+            data.OrthoTop = entity:GetOrthoTop();
+        end
         data.Nearz = entity:GetNearZ();
         data.Farz = entity:GetFarZ();
     elseif entity:GetClass() == "cheap_light" then
-
         data.LightSize = entity:GetLightSize();
     else
         data.InFOV = entity:GetInnerFOV();
@@ -67,11 +72,16 @@ function MOD:Load(entity, data)
         local theclass = entity:GetClass();
         if theclass ~= "expensive_light" and theclass ~= "expensive_light_new" then
             entity:SetLightFOV(data.FOV);
-            end
+        end
+        if theclass == "projected_light_new" then
+            entity:SetOrthoBottom(data.OrthoBottom);
+            entity:SetOrthoLeft(data.OrthoLeft);
+            entity:SetOrthoRight(data.OrthoRight);
+            entity:SetOrthoTop(data.OrthoTop);
+        end
         entity:SetNearZ(data.Nearz);
         entity:SetFarZ(data.Farz);
     elseif entity:GetClass() == "cheap_light" then
-
         entity:SetLightSize(data.LightSize);
     else
         entity:SetInnerFOV(data.InFOV);
@@ -92,7 +102,13 @@ function MOD:LoadBetween(entity, data1, data2, percentage)
         local theclass = entity:GetClass();
         if theclass ~= "expensive_light" and theclass ~= "expensive_light_new" then
             entity:SetLightFOV(SMH.LerpLinear(data1.FOV, data2.FOV, percentage));
-            end
+        end
+        if theclass == "projected_light_new" then
+            entity:SetOrthoBottom(SMH.LerpLinear(data1.OrthoBottom, data2.OrthoBottom, percentage));
+            entity:SetOrthoLeft(SMH.LerpLinear(data1.OrthoLeft, data2.OrthoLeft, percentage));
+            entity:SetOrthoRight(SMH.LerpLinear(data1.OrthoRight, data2.OrthoRight, percentage));
+            entity:SetOrthoTop(SMH.LerpLinear(data1.OrthoTop, data2.OrthoTop, percentage));
+        end
         entity:SetNearZ(SMH.LerpLinear(data1.Nearz, data2.Nearz, percentage));
         entity:SetFarZ(SMH.LerpLinear(data1.Farz, data2.Farz, percentage));
     elseif entity:GetClass() == "cheap_light" then

--- a/lua/smh/modifiers/bodygroup.lua
+++ b/lua/smh/modifiers/bodygroup.lua
@@ -19,6 +19,10 @@ function MOD:LoadGhost(entity, ghost, data)
     self:Load(ghost, data);
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+    self:LoadBetween(ghost, data1, data2, percentage);
+end
+
 function MOD:Load(entity, data)
 
     if self:IsEffect(entity) then

--- a/lua/smh/modifiers/bones.lua
+++ b/lua/smh/modifiers/bones.lua
@@ -30,6 +30,10 @@ function MOD:LoadGhost(entity, ghost, data)
     self:Load(ghost, data);
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+    self:LoadBetween(ghost, data1, data2, percentage);
+end
+
 function MOD:Load(entity, data)
 
     if self:IsEffect(entity) then

--- a/lua/smh/modifiers/flex.lua
+++ b/lua/smh/modifiers/flex.lua
@@ -28,6 +28,10 @@ function MOD:LoadGhost(entity, ghost, data)
     self:Load(ghost, data);
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+    self:LoadBetween(ghost, data1, data2, percentage);
+end
+
 function MOD:Load(entity, data)
 
     if self:IsEffect(entity) then

--- a/lua/smh/modifiers/modelscale.lua
+++ b/lua/smh/modifiers/modelscale.lua
@@ -10,6 +10,10 @@ function MOD:LoadGhost(entity, ghost, data)
     self:Load(ghost, data);
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+    self:LoadBetween(ghost, data1, data2, percentage);
+end
+
 function MOD:Load(entity, data)
     entity:SetModelScale(data.ModelScale);
 end

--- a/lua/smh/modifiers/physbones.lua
+++ b/lua/smh/modifiers/physbones.lua
@@ -90,6 +90,29 @@ function MOD:LoadGhost(entity, ghost, data)
 
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+
+    local count = ghost:GetPhysicsObjectCount();
+
+    for i = 0, count - 1 do
+
+        local pb = ghost:GetPhysicsObjectNum(i);
+
+        local d1 = data1[i];
+        local d2 = data2[i];
+
+        local Pos = SMH.LerpLinearVector(d1.Pos, d2.Pos, percentage);
+        local Ang = SMH.LerpLinearAngle(d1.Ang, d2.Ang, percentage);
+
+        pb:EnableMotion(false);
+            pb:SetPos(Pos);
+        pb:SetAngles(Ang);
+
+        pb:Wake();
+
+    end
+end
+
 function MOD:LoadBetween(entity, data1, data2, percentage, settings)
 
     if settings.IgnorePhysBones then

--- a/lua/smh/modifiers/position.lua
+++ b/lua/smh/modifiers/position.lua
@@ -14,6 +14,10 @@ function MOD:LoadGhost(entity, ghost, data)
     self:Load(ghost, data);
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+    self:LoadBetween(ghost, data1, data2, percentage);
+end
+
 function MOD:Load(entity, data)
 
     entity:SetPos(data.Pos);

--- a/lua/smh/modifiers/skin.lua
+++ b/lua/smh/modifiers/skin.lua
@@ -14,6 +14,10 @@ function MOD:LoadGhost(entity, ghost, data)
     self:Load(ghost, data);
 end
 
+function MOD:LoadGhostBetween(entity, ghost, data1, data2, percentage)
+    self:LoadBetween(ghost, data1, data2, percentage);
+end
+
 function MOD:Load(entity, data)
 
     if self:IsEffect(entity) then

--- a/lua/smh/server/keyframe_data.lua
+++ b/lua/smh/server/keyframe_data.lua
@@ -1,4 +1,4 @@
-function SMH.GetClosestKeyframes(keyframes, frame, ignoreCurrentFrame)
+function SMH.GetClosestKeyframes(keyframes, frame, ignoreCurrentFrame, modname)
     if ignoreCurrentFrame == nil then
         ignoreCurrentFrame = false
     end
@@ -6,15 +6,15 @@ function SMH.GetClosestKeyframes(keyframes, frame, ignoreCurrentFrame)
     local prevKeyframe = nil
     local nextKeyframe = nil
     for _, keyframe in pairs(keyframes) do
-        if keyframe.Frame == frame and not ignoreCurrentFrame then
+        if keyframe.Frame == frame and keyframe.Modifier == modname and not ignoreCurrentFrame then
             prevKeyframe = keyframe
             nextKeyframe = keyframe
             break
         end
 
-        if keyframe.Frame < frame and (not prevKeyframe or prevKeyframe.Frame < keyframe.Frame) then
+        if keyframe.Frame < frame and (not prevKeyframe or prevKeyframe.Frame < keyframe.Frame) and keyframe.Modifier == modname then
             prevKeyframe = keyframe
-        elseif keyframe.Frame > frame and (not nextKeyframe or nextKeyframe.Frame > keyframe.Frame) then
+        elseif keyframe.Frame > frame and (not nextKeyframe or nextKeyframe.Frame > keyframe.Frame) and keyframe.Modifier == modname then
             nextKeyframe = keyframe
         end
     end
@@ -47,6 +47,7 @@ function META:New(player, entity)
         EaseIn = 0,
         EaseOut = 0,
         Modifiers = {},
+        Modifier = "nil"
     }
     self.NextKeyframeId = self.NextKeyframeId + 1
 

--- a/lua/smh/server/modifiers.lua
+++ b/lua/smh/server/modifiers.lua
@@ -6,6 +6,7 @@ function MODBASE:Save(entity) end
 function MODBASE:Load(entity, data, settings) end
 function MODBASE:LoadGhost(entity, ghost, data, settings) end
 function MODBASE:LoadBetween(entity, data1, data2, percentage, settings) end
+function MODBASE:LoadGhostBetween(entity, ghost, data1, data2, percentage, settings) end
 
 function MODBASE:IsEffect(entity) -- checking if the entity is an effect prop
     if entity:GetClass() == "prop_effect" and IsValid(entity.AttachedEntity) then return true end

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -8,28 +8,18 @@ function MGR.SetFrame(player, newFrame, settings)
     end
 
     for entity, keyframes in pairs(SMH.KeyframeData.Players[player].Entities) do
-        local prevKeyframe, nextKeyframe, lerpMultiplier = SMH.GetClosestKeyframes(keyframes, newFrame)
-        if not prevKeyframe then
-            continue
-        end
+        for name, mod in pairs(SMH.Modifiers) do
+            local prevKeyframe, nextKeyframe, lerpMultiplier = SMH.GetClosestKeyframes(keyframes, newFrame, false, name)
+            if not prevKeyframe then
+                continue
+            end
 
-        if lerpMultiplier <= 0 or settings.TweenDisable then
-            for name, mod in pairs(SMH.Modifiers) do
-                if prevKeyframe.Modifiers[name] then
-                    mod:Load(entity, prevKeyframe.Modifiers[name], settings);
-                end
-            end
-        elseif lerpMultiplier >= 1 then
-            for name, mod in pairs(SMH.Modifiers) do
-                if nextKeyframe.Modifiers[name] then
-                    mod:Load(entity, nextKeyframe.Modifiers[name], settings);
-                end
-            end
-        else
-            for name, mod in pairs(SMH.Modifiers) do
-                if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
-                    mod:LoadBetween(entity, prevKeyframe.Modifiers[name], nextKeyframe.Modifiers[name], lerpMultiplier, settings);
-                end
+            if lerpMultiplier <= 0 or settings.TweenDisable then
+                mod:Load(entity, prevKeyframe.Modifiers[name], settings);
+            elseif lerpMultiplier >= 1 then
+                mod:Load(entity, nextKeyframe.Modifiers[name], settings);
+            else
+                mod:LoadBetween(entity, prevKeyframe.Modifiers[name], nextKeyframe.Modifiers[name], lerpMultiplier, settings);
             end
         end
     end

--- a/lua/smh/server/properties_manager.lua
+++ b/lua/smh/server/properties_manager.lua
@@ -4,7 +4,7 @@ SMH.Properties = {
 
 local usednames = {}
 
-local function GetModelName(entity, usedModelNames)
+local function GetModelName(entity)
     local mdl = string.Split(entity:GetModel(), "/")
     mdl = mdl[#mdl]
 

--- a/lua/smh/server/properties_manager.lua
+++ b/lua/smh/server/properties_manager.lua
@@ -66,47 +66,66 @@ end)
 
 local MGR = {}
 
-function MGR.GetAllEntityProperties(player)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities then return nil end
+function MGR.GetAllEntityProperties(player, selectedentity)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities or not IsValid(selectedentity) then return {} end
 
     local info = {}
 
     for entity, value in pairs(SMH.Properties.Players[player].Entities) do
-        info[entity] = {
-            Name = value.Name
-        }
-        table.insert(info, entinfo)
+        if selectedentity == entity then
+            info = {
+                Name = value.Name,
+                Timelines = value.Timelines,
+                TimelineMods = table.Copy(value.TimelineMods),
+            }
+            break
+        end
     end
 
     return info
 end
 
-function MGR.UpdateEntity(player, entity)
-    if not IsValid(entity) then
-        if not SMH.KeyframeData.Players[player] or not SMH.KeyframeData.Players[player].Entities or not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities then return end
-        entity = FindEntity(player)
-        if entity then
-            usednames[SMH.Properties.Players[player].Entities[entity].Name] = nil
-            SMH.Properties.Players[player].Entities[entity] = nil
-        end
-    else
-        if not SMH.KeyframeData.Players[player] or not SMH.KeyframeData.Players[player].Entities[entity] then
-            if SMH.Properties.Players[player] and SMH.Properties.Players[player].Entities[entity] then
-                SMH.Properties.Players[player].Entities[entity] = nil
-            end
-            return
-        end
+function MGR.GetAllProperties(player)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities then return {} end
 
-        if not SMH.Properties.Players[player] then
-            SMH.Properties.Players[player] = { Entities = {} }
-        end
+    local info = {}
 
-        if not SMH.Properties.Players[player].Entities[entity] then
-            SMH.Properties.Players[player].Entities[entity] = {
-                Name = SetUniqueName(player, entity, GetModelName(entity))
-            }
-        end
-        usednames[SMH.Properties.Players[player].Entities[entity].Name] = true
+    for entity, value in pairs(SMH.Properties.Players[player].Entities) do
+        info[entity] = {
+            Name = value.Name,
+            Timelines = value.Timelines,
+            TimelineMods = table.Copy(value.TimelineMods),
+        }
+    end
+
+    return info
+end
+
+function MGR.GetAllEntitiesNames(player)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities then return {} end
+
+    local info = {}
+
+    for entity, value in pairs(SMH.Properties.Players[player].Entities) do
+        info[entity] = {
+            Name = value.Name,
+        }
+    end
+
+    return info
+end
+
+function MGR.CheckEntity(player, entity)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities or not SMH.Properties.Players[player].Entities[entity] then return true end
+    return false
+end
+
+function MGR.RemoveEntity(player)
+    if not SMH.KeyframeData.Players[player] or not SMH.KeyframeData.Players[player].Entities or not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities then return end
+    local entity = FindEntity(player)
+    if entity then
+        usednames[SMH.Properties.Players[player].Entities[entity].Name] = nil
+        SMH.Properties.Players[player].Entities[entity] = nil
     end
 end
 
@@ -116,11 +135,28 @@ function MGR.AddEntity(player, entity)
     end
 
     if not SMH.Properties.Players[player].Entities[entity] then
+        local template = SMH.Saves.GetPreferences(player)
+        local timelines
+        local timelinemods = {}
+        if not template then
+            timelines = 1
+
+            timelinemods[1] = { KeyColor = Color(0, 200, 0) }
+
+            for name, mod in pairs(SMH.Modifiers) do
+                table.insert(timelinemods[1], name)
+            end
+        else
+            timelines = template.Timelines
+
+            timelinemods = table.Copy(template.TimelineMods)
+        end
         SMH.Properties.Players[player].Entities[entity] = {
-            Name = SetUniqueName(player, entity, GetModelName(entity))
+            Name = SetUniqueName(player, entity, GetModelName(entity)),
+            Timelines = timelines,
+            TimelineMods = timelinemods
         }
     end
-
     usednames[SMH.Properties.Players[player].Entities[entity].Name] = true
 end
 
@@ -132,6 +168,67 @@ function MGR.SetName(player, entity, newname)
     SMH.Properties.Players[player].Entities[entity].Name = newname
 
     return newname
+end
+
+function MGR.SetTimelines(player, entity, add)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+
+    local timelines = SMH.Properties.Players[player].Entities[entity].Timelines
+    local count
+    if add then
+        count = timelines + 1
+    else
+        count = timelines - 1
+    end
+
+    if count > 10 or count < 1 then return end  -- just in case
+
+    if add then
+        SMH.Properties.Players[player].Entities[entity].TimelineMods[count] = { KeyColor = Color(0, 200, 0) }
+    else
+        SMH.Properties.Players[player].Entities[entity].TimelineMods[timelines] = nil
+    end
+
+    SMH.Properties.Players[player].Entities[entity].Timelines = count
+end
+
+function MGR.UpdateModifier(player, entity, itimeline, name, state)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+
+    if state then 
+        table.insert(SMH.Properties.Players[player].Entities[entity].TimelineMods[itimeline], name)
+        for i = 1, SMH.Properties.Players[player].Entities[entity].Timelines do
+            if i == itimeline then continue end
+            table.RemoveByValue(SMH.Properties.Players[player].Entities[entity].TimelineMods[i], name)
+        end
+    else
+        table.RemoveByValue(SMH.Properties.Players[player].Entities[entity].TimelineMods[itimeline], name)
+    end
+
+    return name
+end
+
+function MGR.UpdateKeyframeColor(player, entity, color, timeline)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+
+    SMH.Properties.Players[player].Entities[entity].TimelineMods[timeline].KeyColor = color
+end
+
+function MGR.GetTimelines(player, entity)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return 1 end
+    return SMH.Properties.Players[player].Entities[entity].Timelines
+end
+
+function MGR.SetProperties(player, entity, properties)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+
+    local newname = SetUniqueName(player, entity, properties.Name)
+    SMH.Properties.Players[player].Entities[entity].Name = newname
+    SMH.Properties.Players[player].Entities[entity].Timelines = properties.Timelines
+    SMH.Properties.Players[player].Entities[entity].TimelineMods = properties.TimelineMods
+    if properties.Old then
+        SMH.Properties.Players[player].Entities[entity].Old = true
+    end
 end
 
 SMH.PropertiesManager = MGR

--- a/lua/smh/shared.lua
+++ b/lua/smh/shared.lua
@@ -61,3 +61,4 @@ for key, val in pairs(SMH.MessageTypes) do
 end
 
 include("shared/saves.lua")
+include("shared/tablesplit.lua")

--- a/lua/smh/shared.lua
+++ b/lua/smh/shared.lua
@@ -41,6 +41,19 @@ SMH.MessageTypes = {
 
     "ApplyEntityName",
     "ApplyEntityNameResponse",
+    "UpdateTimeline",
+    "UpdateTimelineResponse",
+    "RequestModifiers",
+    "RequestModifiersResponse",
+    "AddTimeline",
+    "RemoveTimeline",
+    "UpdateTimelineInfoResponse",
+    "UpdateModifier",
+    "UpdateModifierResponse",
+    "UpdateKeyframeColor",
+    "UpdateKeyframeColorResponse",
+
+    "SaveProperties",
 }
 for key, val in pairs(SMH.MessageTypes) do
     local prefixVal = "SMH" .. val

--- a/lua/smh/shared/tablesplit.lua
+++ b/lua/smh/shared/tablesplit.lua
@@ -1,0 +1,116 @@
+local keyframesAssembling = {}
+local timelineAssembling = {}
+local listAssembling = {}
+
+local MGR = {} -- btw D stands for "deconstruct", A for "Assemble"
+
+function MGR.DKeyframes(keyframes)
+    local IDs, ent, Frame, In, Out, Modifiers, Modifier = {}, {}, {}, {}, {}, {}, {}
+    local i = 0
+    for _, keyframe in pairs(keyframes) do
+        i = i + 1
+
+        IDs[i] = keyframe.ID
+        Frame[i] = keyframe.Frame
+        ent = keyframe.Entity -- We won't be using keyframes from multiple entities with these functions anyway
+        In[i] = keyframe.EaseIn
+        Out[i] = keyframe.EaseOut
+        Modifiers[i] = keyframe.Modifiers
+        Modifier[i] = keyframe.Modifier
+    end
+
+    return i, IDs, ent, Frame, In, Out, Modifiers, Modifier
+end
+
+function MGR.AKeyframes(ID, entity, Frame, In, Out, Modifiers, Modifier)
+    local keyframe = {}
+    keyframe.ID = ID
+    keyframe.Entity = entity
+    keyframe.Frame = Frame
+    keyframe.EaseIn = In
+    keyframe.EaseOut = Out
+    if Modifiers then
+        keyframe.Modifiers = table.Copy(Modifiers)
+    end
+    keyframe.Modifier = Modifier
+
+    table.insert(keyframesAssembling, keyframe)
+end
+
+function MGR.GetKeyframes()
+    local keyframes = table.Copy(keyframesAssembling)
+    keyframesAssembling = {}
+    return keyframes
+end
+
+function MGR.DProperties(timeline)
+    if not next(timeline) then return end
+    local Name, Timelines = timeline.Name, timeline.Timelines
+    local KeyColor, Modifiers, ModCount = {}, {}, {}
+
+    for key, _ in ipairs(timeline.TimelineMods) do
+        Modifiers[key] = {}
+        ModCount[key] = #timeline.TimelineMods[key]
+
+        for k, value in pairs(timeline.TimelineMods[key]) do
+            if k == "KeyColor" then
+                KeyColor[key] = value
+                continue
+            end
+
+            Modifiers[key][k] = value
+        end
+    end
+    return Name, Timelines, KeyColor, ModCount, Modifiers
+end
+
+function MGR.StartAProperties(Name, Timelines)
+    timelineAssembling.Name = Name
+    timelineAssembling.Timelines = Timelines
+    timelineAssembling.TimelineMods = {}
+    return Timelines
+end
+
+function MGR.AProperties(Timeline, Modifier, KeyColor)
+    if not timelineAssembling.TimelineMods[Timeline] then
+        timelineAssembling.TimelineMods[Timeline] = {}
+    end
+    if KeyColor then
+        timelineAssembling.TimelineMods[Timeline].KeyColor = KeyColor
+    end
+    if Modifier then
+        table.insert(timelineAssembling.TimelineMods[Timeline], Modifier)
+    end
+end
+
+function MGR.GetProperties()
+    local timeline = table.Copy(timelineAssembling)
+    timelineAssembling = {}
+    return timeline
+end
+
+function MGR.DList(list)
+    local items, keys, count = {}, {}, 0
+    for key, item in pairs(list) do
+        table.insert(items, item)
+        table.insert(keys, key)
+        count = count + 1
+    end
+    return items, keys, count
+end
+
+function MGR.AList(key, item)
+    if not tonumber(key) then
+        listAssembling[key] = item
+    else
+        listAssembling[tonumber(key)] = item
+    end
+end
+
+function MGR.GetList()
+    local list = table.Copy(listAssembling)
+    listAssembling = {}
+    return list
+end
+
+SMH.TableSplit = MGR


### PR DESCRIPTION
- Updated properties window
- SMH can now record modifiers on up to 10 timelines per entity, that also supports ghosting
- Timeline setup can be saved with "smh_savepreset", which will apply currently selected entity's timeline setup to all other entities user will record in the future
- Compatible with saves from SMH that's currently on the workshop
- Also added some of the properties that I missed for advanced light modifier
- There's also list of all currently recorded entities in the properties window, which allows you to select them without having to use right click
- Colors of keyframes are set per timeline, and they can be changed now. Should help with clarifying which timeline is currently selected.