### PR TITLE
Added smooth playback setting

### DIFF
--- a/lua/smh/client/derma/settings.lua
+++ b/lua/smh/client/derma/settings.lua
@@ -42,6 +42,7 @@ function PANEL:Init()
     self.GhostNextFrame = CreateCheckBox("GhostNextFrame", "Ghost next frame")
     self.GhostAllEntities = CreateCheckBox("GhostAllEntities", "Ghost all entities")
     self.TweenDisable = CreateCheckBox("TweenDisable", "Disable tweening")
+    self.SmoothPlayback = CreateCheckBox("SmoothPlayback", "Smooth playback")
     self.GhostTransparency = CreateSlider("GhostTransparency", "Ghost transparency", 0, 1, 2)
 
     self.HelpButton = vgui.Create("DButton", self)
@@ -50,7 +51,7 @@ function PANEL:Init()
         self:OnRequestOpenHelp()
     end
 
-    self:SetSize(250, 225)
+    self:SetSize(250, 245)
 
     self._changingSettings = false
 
@@ -72,10 +73,12 @@ function PANEL:PerformLayout(width, height)
 
     self.TweenDisable:SetPos(5, 145)
 
-    self.GhostTransparency:SetPos(5, 165)
+    self.SmoothPlayback:SetPos(5, 165)
+
+    self.GhostTransparency:SetPos(5, 185)
     self.GhostTransparency:SetSize(self:GetWide() - 5 - 5, 25)
 
-    self.HelpButton:SetPos(5, 200)
+    self.HelpButton:SetPos(5, 210)
     self.HelpButton:SetSize(self:GetWide() - 5 - 5, 20)
 
 end
@@ -91,6 +94,7 @@ function PANEL:ApplySettings(settings)
         "GhostNextFrame",
         "GhostAllEntities",
         "TweenDisable",
+        "SmoothPlayback",
     }
 
     for _, key in pairs(checkBoxes) do

--- a/lua/smh/client/settings.lua
+++ b/lua/smh/client/settings.lua
@@ -55,6 +55,7 @@ local ConVars = {
     GhostTransparency = CreateTypedConVar(ConVarType.Float, "smh_ghosttransparency", 0.5),
     OnionSkin = CreateTypedConVar(ConVarType.Bool, "smh_onionskin", false),
     TweenDisable = CreateTypedConVar(ConVarType.Bool, "smh_tweendisable", false),
+    SmoothPlayback = CreateTypedConVar(ConVarType.Bool, "smh_smoothplayback", false)
 }
 
 local MGR = {}

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -294,7 +294,7 @@ hook.Add("InitPostEntity", "SMHMenuSetup", function()
     WorldClicker.MainMenu = vgui.Create("SMHMenu", WorldClicker)
 
     WorldClicker.Settings = vgui.Create("SMHSettings", WorldClicker)
-    WorldClicker.Settings:SetPos(ScrW() - 250, ScrH() - 90 - 225)
+    WorldClicker.Settings:SetPos(ScrW() - 250, ScrH() - 90 - 245)
     WorldClicker.Settings:SetVisible(false)
 
     SaveMenu = vgui.Create("SMHSave")

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -2,6 +2,41 @@ local ActivePlaybacks = {}
 
 local MGR = {}
 
+local function PlaybackSmooth(player, playback, settings)
+    playback.Timer = playback.Timer + FrameTime()
+    local timePerFrame = 1 / playback.PlaybackRate
+
+    playback.CurrentFrame = playback.Timer / timePerFrame + playback.StartFrame
+    if playback.CurrentFrame > playback.EndFrame then
+        playback.CurrentFrame = 0
+        playback.StartFrame = 0
+        playback.Timer = 0
+    end
+
+    for entity, keyframes in pairs(SMH.KeyframeData.Players[player].Entities) do
+        local prevKeyframe, nextKeyframe, _ = SMH.GetClosestKeyframes(keyframes, playback.CurrentFrame)
+
+        if not prevKeyframe then continue end
+
+        if prevKeyframe.Frame == nextKeyframe.Frame then
+            for name, mod in pairs(SMH.Modifiers) do
+                if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
+                    mod:Load(entity, prevKeyframe.Modifiers[name], settings);
+                end
+            end
+        else
+            local lerpMultiplier = ((playback.Timer + playback.StartFrame * timePerFrame) - prevKeyframe.Frame * timePerFrame) / ((nextKeyframe.Frame - prevKeyframe.Frame) * timePerFrame)
+            lerpMultiplier = math.EaseInOut(lerpMultiplier, prevKeyframe.EaseOut, nextKeyframe.EaseIn)
+
+            for name, mod in pairs(SMH.Modifiers) do
+                if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
+                    mod:LoadBetween(entity, prevKeyframe.Modifiers[name], nextKeyframe.Modifiers[name], lerpMultiplier, settings);
+                end
+            end
+        end
+    end
+end
+
 function MGR.SetFrame(player, newFrame, settings)
     if not SMH.KeyframeData.Players[player] then
         return
@@ -43,16 +78,20 @@ end
 
 hook.Add("Think", "SMHPlaybackManagerThink", function()
     for player, playback in pairs(ActivePlaybacks) do
-        playback.Timer = playback.Timer + FrameTime()
-        local timePerFrame = 1 / playback.PlaybackRate
-        if playback.Timer >= timePerFrame then
-            playback.CurrentFrame = math.floor(playback.Timer / timePerFrame) + playback.StartFrame
-            if playback.CurrentFrame > playback.EndFrame then
-                playback.CurrentFrame = 0
-                playback.StartFrame = 0
-                playback.Timer = 0
+        if not playback.Settings.SmoothPlayback then
+            playback.Timer = playback.Timer + FrameTime()
+            local timePerFrame = 1 / playback.PlaybackRate
+            if playback.Timer >= timePerFrame then
+                playback.CurrentFrame = math.floor(playback.Timer / timePerFrame) + playback.StartFrame
+                if playback.CurrentFrame > playback.EndFrame then
+                    playback.CurrentFrame = 0
+                    playback.StartFrame = 0
+                    playback.Timer = 0
+                end
+                MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
             end
-            MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
+        else
+            PlaybackSmooth(player, playback, playback.Settings)
         end
     end
 end)

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -3,7 +3,7 @@ local ActivePlaybacks = {}
 local MGR = {}
 
 local function PlaybackSmooth(player, playback, settings)
-	if not SMH.KeyframeData.Players[player] then
+    if not SMH.KeyframeData.Players[player] then
         return
     end
 
@@ -18,24 +18,24 @@ local function PlaybackSmooth(player, playback, settings)
     end
 
     for entity, keyframes in pairs(SMH.KeyframeData.Players[player].Entities) do
-		for name, mod in pairs(SMH.Modifiers) do
-			local prevKeyframe, nextKeyframe, _ = SMH.GetClosestKeyframes(keyframes, playback.CurrentFrame, false, name)
+        for name, mod in pairs(SMH.Modifiers) do
+            local prevKeyframe, nextKeyframe, _ = SMH.GetClosestKeyframes(keyframes, playback.CurrentFrame, false, name)
 
-			if not prevKeyframe then continue end
+            if not prevKeyframe then continue end
 
-			if prevKeyframe.Frame == nextKeyframe.Frame then
-				if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
-					mod:Load(entity, prevKeyframe.Modifiers[name], settings);
-				end
-			else
-				local lerpMultiplier = ((playback.Timer + playback.StartFrame * timePerFrame) - prevKeyframe.Frame * timePerFrame) / ((nextKeyframe.Frame - prevKeyframe.Frame) * timePerFrame)
-				lerpMultiplier = math.EaseInOut(lerpMultiplier, prevKeyframe.EaseOut, nextKeyframe.EaseIn)
+            if prevKeyframe.Frame == nextKeyframe.Frame then
+                if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
+                    mod:Load(entity, prevKeyframe.Modifiers[name], settings);
+                end
+            else
+                local lerpMultiplier = ((playback.Timer + playback.StartFrame * timePerFrame) - prevKeyframe.Frame * timePerFrame) / ((nextKeyframe.Frame - prevKeyframe.Frame) * timePerFrame)
+                lerpMultiplier = math.EaseInOut(lerpMultiplier, prevKeyframe.EaseOut, nextKeyframe.EaseIn)
 
-				if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
-					mod:LoadBetween(entity, prevKeyframe.Modifiers[name], nextKeyframe.Modifiers[name], lerpMultiplier, settings);
-				end
-			end
-		end
+                if prevKeyframe.Modifiers[name] and nextKeyframe.Modifiers[name] then
+                    mod:LoadBetween(entity, prevKeyframe.Modifiers[name], nextKeyframe.Modifiers[name], lerpMultiplier, settings);
+                end
+            end
+        end
     end
 end
 


### PR DESCRIPTION
- Uses playback way that is a bit based on what HAT did, rather than switching frames it straight up interpolates modifier info between keyframes. Would be useful for people who do video recordings of the SMH playback rather than screenshotting. (Although only ragdolls get the most impact from that)