### PR TITLE
Keyframe multiselection

### DIFF
--- a/lua/smh/client/derma/frame_pointer.lua
+++ b/lua/smh/client/derma/frame_pointer.lua
@@ -122,7 +122,6 @@ function PANEL:OnMousePressed(mousecode)
     self._dragging = true
 
     SMH.UI.SetOffsets(self)
-    SMH.UI.AssignFrames(self)
 end
 
 function PANEL:SetParentPointer(ppointer)
@@ -158,8 +157,7 @@ function PANEL:OnMouseReleased(mousecode)
         return
     end
 
-    self._minoffset = 0
-    self._maxoffset = 0
+    self:SetOffsets(0, 0)
 
     self:MouseCapture(false)
     self._dragging = false

--- a/lua/smh/client/derma/frame_pointer.lua
+++ b/lua/smh/client/derma/frame_pointer.lua
@@ -24,7 +24,9 @@ function PANEL:Init()
 
     self._frame = 0
     self._dragging = false
-    self._mod = "nil"
+    self._mod = "nil"    self._selected = false
+    self._maxoffset = 0
+    self._minoffset = 0
 
 end
 
@@ -34,7 +36,7 @@ function PANEL:Paint(width, height)
         return
     end
 
-    local outlineColor = (self._dragging and self.OutlineColorDragged) or self.OutlineColor
+    local outlineColor = ((self._selected or self._dragging) and self.OutlineColorDragged) or self.OutlineColor
 
     if self.PointyBottom then
 
@@ -94,6 +96,14 @@ function PANEL:IsDragging()
     return self._dragging
 end
 
+function PANEL:SetSelected(selected)
+    self._selected = selected
+end
+
+function PANEL:GetSelected()
+    return self._selected
+end
+
 function PANEL:GetMod()
     return self._mod
 end
@@ -111,24 +121,25 @@ function PANEL:OnMousePressed(mousecode)
     self:MouseCapture(true)
     self._dragging = true
 
+    SMH.UI.SetOffsets(self)
     SMH.UI.AssignFrames(self)
-
-    local parent = self:GetParent() -- this is the part from OnCursorMoved(), mostly needed to the cases when we copy and paste a frame on top of itself, as by default it seems to go back to frame 0
-
-    local cursorX, cursorY = parent:CursorPos()
-    local startX, endX = unpack(parent.FrameArea)
-
-    local targetX = cursorX - startX
-    local width = endX - startX
-
-    local targetPos = math.Round(parent.ScrollOffset + (targetX / width) * parent.Zoom)
-    targetPos = targetPos < 0 and 0 or (targetPos >= parent.TotalFrames and parent.TotalFrames - 1 or targetPos)
-
-    if targetPos ~= self._frame then
-        self:SetFrame(targetPos)
-        SMH.UI.MoveChildren(self, targetPos)
-    end
 end
+
+function PANEL:SetParentPointer(ppointer)
+    self.parent = ppointer
+end
+
+function PANEL:ClearParentPointer()
+    self.parent = nil
+end
+
+function PANEL:GetParentKeyframe()
+    return self.parent
+end
+
+function PANEL:SetOffsets(minimum, maximum)
+    self._minoffset = minimum
+    self._maxoffset = maximumend
 
 function PANEL:SetParentPointer(ppointer)
     self.parent = ppointer
@@ -147,10 +158,23 @@ function PANEL:OnMouseReleased(mousecode)
         return
     end
 
+    self._minoffset = 0
+    self._maxoffset = 0
+
     self:MouseCapture(false)
     self._dragging = false
     SMH.UI.ClearFrames(self)
     self:OnPointerReleased(self._frame)
+
+    if mousecode == MOUSE_LEFT then
+        if input.IsKeyDown(KEY_LSHIFT) then
+            SMH.UI.ShiftSelect(self)
+        elseif input.IsKeyDown(KEY_LCONTROL) then
+            SMH.UI.ToggleSelect(self)
+        else
+            SMH.UI.ClearAllSelected()
+        end
+    end
 end
 
 function PANEL:OnCursorMoved()
@@ -167,9 +191,10 @@ function PANEL:OnCursorMoved()
     local width = endX - startX
 
     local targetPos = math.Round(parent.ScrollOffset + (targetX / width) * parent.Zoom)
-    targetPos = targetPos < 0 and 0 or (targetPos >= parent.TotalFrames and parent.TotalFrames - 1 or targetPos)
+    targetPos = targetPos < 0 - self._minoffset and 0 - self._minoffset or (targetPos >= parent.TotalFrames - self._maxoffset and parent.TotalFrames - 1 - self._maxoffset or targetPos)
 
     if targetPos ~= self._frame then
+        SMH.UI.MoveChildren(self, targetPos)
         self:SetFrame(targetPos)
         self:OnFrameChanged(targetPos)
         SMH.UI.MoveChildren(self, targetPos)

--- a/lua/smh/client/derma/frame_pointer.lua
+++ b/lua/smh/client/derma/frame_pointer.lua
@@ -24,7 +24,8 @@ function PANEL:Init()
 
     self._frame = 0
     self._dragging = false
-    self._mod = "nil"    self._selected = false
+    self._mod = "nil"
+    self._selected = false
     self._maxoffset = 0
     self._minoffset = 0
 
@@ -121,6 +122,7 @@ function PANEL:OnMousePressed(mousecode)
     self:MouseCapture(true)
     self._dragging = true
 
+    SMH.UI.AssignFrames(self)
     SMH.UI.SetOffsets(self)
 end
 
@@ -138,7 +140,8 @@ end
 
 function PANEL:SetOffsets(minimum, maximum)
     self._minoffset = minimum
-    self._maxoffset = maximumend
+    self._maxoffset = maximum
+end
 
 function PANEL:SetParentPointer(ppointer)
     self.parent = ppointer

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -9,9 +9,10 @@ local KeyframeEasingData = {}
 local SelectedPointers = {}
 local OffsetPointers = {}
 local LastID = 0
-local ClickerEntity = nil
 local LastSelectedKeyframe = nil
 local KeyColor = Color(0, 200, 0)
+
+local ClickerEntity = nil
 
 local function CreateCopyPointer(keyframeId, mods)
     OffsetPointers = {}
@@ -23,15 +24,17 @@ local function CreateCopyPointer(keyframeId, mods)
     for id, kpointer in pairs(KeyframePointers) do
         if id == keyframeId then continue end
         if SelectedPointers[id] then
+            local difference = kpointer:GetFrame() - originFrame
+
             kpointer:SetSelected(false)
             SelectedPointers[id] = nil
 
-            local difference = kpointer:GetFrame() - originFrame
             local pointer = WorldClicker.MainMenu.FramePanel:CreateFramePointer(
             Color(0, 200, 0),
             WorldClicker.MainMenu.FramePanel:GetTall() / 4 * 2.2,
             false
             )
+
             table.insert(OffsetPointers, pointer)
             pointer:SetFrame(originFrame + difference)
             pointer:SetSelected(true)
@@ -345,7 +348,6 @@ function MGR.SetFrame(frame)
 end
 
 function MGR.SetKeyframes(keyframes)
-
     for _, pointer in pairs(KeyframePointers) do
         WorldClicker.MainMenu.FramePanel:DeleteFramePointer(pointer)
     end
@@ -414,7 +416,7 @@ function MGR.DeleteKeyframe(keyframeId)
     end
 
     if KeyframePointers[keyframeId] == LastSelectedKeyframe then LastSelectedKeyframe = nil end
-    SelectedPointers[KeyframePointers[keyframeId]] = nil
+    SelectedPointers[keyframeId] = nil
     WorldClicker.MainMenu.FramePanel:DeleteFramePointer(KeyframePointers[keyframeId])
     KeyframePointers[keyframeId] = nil
     KeyframeEasingData[keyframeId] = nil
@@ -440,26 +442,6 @@ function MGR.SetOffsets(pointer)
         end
     end
     pointer:SetOffsets(minimum, maximum)
-end
-
-function MGR.AssignFrames(pointer)
-    local frame = pointer:GetFrame()
-    local keyID
-    for id, kpointer in pairs(KeyframePointers) do
-        if pointer == kpointer then
-            keyID = id
-            break
-        end
-    end
-
-    if not keyID then return end
-
-    for id, kpointer in pairs(KeyframePointers) do
-        if keyID == id then continue end
-        if kpointer:GetFrame() == frame then
-            kpointer:SetParentPointer(pointer)
-        end
-    end
 end
 
 function MGR.MoveChildren(pointer, frame)


### PR DESCRIPTION
- Added ability to select and move, copy, and delete multiple keyframes on the timeline. Ctrl + Left click will select keyframes one at a time, Shift + Left click will select everything between the keyframe that you pressed and the last selected keyframe.
- After selecting keyframes, using usual left click to move, right click to delete, middle click/right click and ctrl to copy will apply to all other selected keyframes.
- Left clicking any frame without holding ctrl or shift will unselect everything
- Moving multiple keyframes wouldn't let them get ouside of the framecount set bounds, unless one of the selected keyframes was already outside of the bounds, like recording a frame at position 99 and then reducing framecount to 50. For those cases, frames that end up being in position < 0 will be deleted.