### PR TITLE
Tweaks pass

### DIFF
--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -154,7 +154,7 @@ function CTRL.QuickSave()
     local qs2 = "quicksave_" .. nick .. "_backup"
 
     SMH.Saves.CopyIfExists(qs1, qs2)
-    CTRL.Save(qs1, true)
+    CTRL.Save(qs1, false)
 end
 
 function CTRL.DeleteSave(path, deleteFromClient)

--- a/lua/smh/client/physrecord.lua
+++ b/lua/smh/client/physrecord.lua
@@ -64,7 +64,7 @@ function MGR.RecordToggle()
                     Active = false
                     Waiting = 0
                     timer.Remove(SMHRecorderID)
-                    LocalPlayer():ChatPrint( "SMH Physics Recoder stopped.")
+                    LocalPlayer():ChatPrint( "SMH Physics Recorder stopped.")
 
                 else
                     NextFrame()
@@ -76,7 +76,7 @@ function MGR.RecordToggle()
         Active = false
         Waiting = 0
         timer.Remove(SMHRecorderID)
-        LocalPlayer():ChatPrint( "SMH Physics Recoder stopped.")
+        LocalPlayer():ChatPrint( "SMH Physics Recorder stopped.")
     end
 
 end

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -116,7 +116,7 @@ end
 
 hook.Add("Think", "SMHPlaybackManagerThink", function()
     for player, playback in pairs(ActivePlaybacks) do
-        if not playback.Settings.SmoothPlayback then
+        if not playback.Settings.SmoothPlayback or playback.Settings.TweenDisable then
             playback.Timer = playback.Timer + FrameTime()
             local timePerFrame = 1 / playback.PlaybackRate
             if playback.Timer >= timePerFrame then


### PR DESCRIPTION
First small tweaks and fixes pass based on the feedback from public test:
- Fixed a mispell in the physics recorder stop message
- Fixed quicksave trying to send keyframes back to client despite the fact that we don't save them on the client yet
- Set disable tweening setting to be prioritized over smooth playback