### PR TITLE
Player bound timelines

### DIFF
--- a/lua/smh/client/concommands.lua
+++ b/lua/smh/client/concommands.lua
@@ -68,8 +68,5 @@ concommand.Add("smh_makescreenshot", function(pl, cmd, args)
     end
 end)
 
-concommand.Add("smh_savepreset", function()
-    SMH.Controller.SaveProperties()
-end)
-
 CreateClientConVar("smh_startatone", 0, true, false, nil, 0, 1)
+CreateClientConVar("smh_currentpreset", "default", true, false)

--- a/lua/smh/client/derma/properties.lua
+++ b/lua/smh/client/derma/properties.lua
@@ -204,7 +204,7 @@ function PANEL:PerformLayout(width, height)
     self.AddSettingPresetButton:SetSize(20, 20)
 
     self.TimelinesCList:SetPos(5, 70)
-    self.TimelinesCList:SetSize(self.TimelinesPanel:GetWide() - 10, self.TimelinesPanel:GetTall() - 55 - 5)
+    self.TimelinesCList:SetSize(self.TimelinesPanel:GetWide() - 10, self.TimelinesPanel:GetTall() - 70 - 5)
 
     self.AddTimeButton:SetPos(5, 50)
     self.AddTimeButton:SetSize(self.TimelinesCList:GetWide() / 2 - 2, 20)

--- a/lua/smh/client/derma/properties.lua
+++ b/lua/smh/client/derma/properties.lua
@@ -5,6 +5,7 @@ local ModifierList = {}
 local Fallback = "none"
 local selectedEntity = nil
 local UsingWorld = false
+local IsSaving = false
 
 local function GetModelName(entity)
     local mdl = string.Split(entity:GetModel(), "/");
@@ -85,6 +86,20 @@ function PANEL:Init()
 
     self.TimelinesPanel = vgui.Create("DPanel", self)
     self.TimelinesPanel:SetBackgroundColor(Color(155, 155, 155, 255))
+
+    self.SettingPicker = vgui.Create("DComboBox", self.TimelinesPanel)
+    self.SettingPicker.OnSelect = function(_, index, value)
+        RunConsoleCommand("smh_currentpreset", value)
+        local settings = SMH.Saves.GetPreferences(value)
+        if not settings and not value == "default" then return end
+        self:SetSettings(settings, value)
+    end
+
+    self.AddSettingPresetButton = vgui.Create("DButton", self.TimelinesPanel)
+    self.AddSettingPresetButton:SetText("+")
+    self.AddSettingPresetButton.DoClick = function()
+        self:MakeSettingSavePanel()
+    end
 
     self.SelectedEntityLabel = vgui.Create("DLabel", self.TimelinesPanel)
     self.SelectedEntityLabel:SetText("Selected model: " .. "none")
@@ -182,13 +197,19 @@ function PANEL:PerformLayout(width, height)
     self.SelectedEntityLabel:SetPos(4, 5)
     self.SelectedEntityLabel:SetSize(self.TimelinesPanel:GetWide() - 8, 15)
 
-    self.TimelinesCList:SetPos(5, 55)
+    self.SettingPicker:SetPos(4, 25)
+    self.SettingPicker:SetSize(self.TimelinesPanel:GetWide() - 10 - 25, 20)
+
+    self.AddSettingPresetButton:SetPos(self.TimelinesPanel:GetWide() - 8 - 20, 25)
+    self.AddSettingPresetButton:SetSize(20, 20)
+
+    self.TimelinesCList:SetPos(5, 70)
     self.TimelinesCList:SetSize(self.TimelinesPanel:GetWide() - 10, self.TimelinesPanel:GetTall() - 55 - 5)
 
-    self.AddTimeButton:SetPos(5, 35)
+    self.AddTimeButton:SetPos(5, 50)
     self.AddTimeButton:SetSize(self.TimelinesCList:GetWide() / 2 - 2, 20)
 
-    self.RemoveTimeButton:SetPos(5 + self.TimelinesCList:GetWide() / 2 + 2, 35)
+    self.RemoveTimeButton:SetPos(5 + self.TimelinesCList:GetWide() / 2 + 2, 50)
     self.RemoveTimeButton:SetSize(self.TimelinesCList:GetWide() / 2 - 2, 20)
 
     self.ColorPanel:SetPos(248 + self:GetWide() - 456 + 4, 30)
@@ -221,6 +242,38 @@ function PANEL:PerformLayout(width, height)
     self.ButtonReleaseEnter:SetSize(self.WorldParent:GetWide() - 10, 20)
         self.ButtonReleaseEnter.Label:SetRelativePos(self.ButtonReleaseEnter, 2, -5 - self.ButtonReleaseEnter.Label:GetTall())
 
+end
+
+function PANEL:MakeSettingSavePanel()
+    if IsSaving then return end
+
+    IsSaving = true
+
+    local savepanel = vgui.Create("DFrame")
+    savepanel:SetTitle("Save Timeline Preset")
+    savepanel:SetPos((ScrW() / 2) - 100, (ScrH() / 2) - 50)
+    savepanel:SetSize(200, 100)
+    savepanel:MakePopup()
+
+    savepanel.TextEnter = vgui.Create("DTextEntry", savepanel)
+    savepanel.TextEnter:SetPos(50, 45)
+    savepanel.TextEnter:SetSize(100, 20)
+
+    savepanel.SaveButton = vgui.Create("DButton", savepanel)
+    savepanel.SaveButton:SetPos(75, 75)
+    savepanel.SaveButton:SetSize(50, 20)
+    savepanel.SaveButton:SetText("Save")
+
+    savepanel.SaveButton.DoClick = function()
+        local text = savepanel.TextEnter:GetValue()
+        if text == "" or text == "default" then return end
+        self:SaveSettingsPreset(text)
+        savepanel:Close()
+    end
+
+    savepanel.OnClose = function()
+        IsSaving = false
+    end
 end
 
 function PANEL:UpdateSelectedEnt(ent)
@@ -305,6 +358,21 @@ function PANEL:GetCurrentModifiers()
     return PropertyTable.TimelineMods[SMH.State.Timeline]
 end
 
+function PANEL:UpdateTimelineSettings()
+    self.SettingPicker:Clear()
+    self.SettingPicker:AddChoice("default")
+
+    for _, setting in ipairs(SMH.Saves.ListSettings()) do
+        self.SettingPicker:AddChoice(setting)
+    end
+
+    if ConVarExists("smh_currentpreset") then
+        self.SettingPicker:SetValue(GetConVar("smh_currentpreset"):GetString())
+    else
+        self.SettingPicker:SetValue("default")
+    end
+end
+
 function PANEL:SetEntities(entities)
     local entlist = {}
     EntsTable = table.Copy(entities)
@@ -377,6 +445,20 @@ function PANEL:HideWorldSettings()
     self.WorldParent:SetVisible(false)
 end
 
+function PANEL:InitTimelineSettings()
+    local value
+
+    if ConVarExists("smh_currentpreset") then
+        value = GetConVar("smh_currentpreset"):GetString()
+    else
+        value = "default"
+    end
+
+    local settings = SMH.Saves.GetPreferences(value)
+    if not settings then value = "default" end
+    self:SetSettings(settings, value)
+end
+
 function PANEL:ApplyName(ent, name) end
 function PANEL:SelectEntity(entity) end
 function PANEL:SelectWorld() end
@@ -385,5 +467,7 @@ function PANEL:OnRemoveTimelineRequested() end
 function PANEL:OnUpdateModifierRequested(i, mod, check) end
 function PANEL:OnUpdateKeyframeColorRequested(color, timeline) end
 function PANEL:SetData(str, key) end
+function PANEL:SetSettings(settings, presetname) end
+function PANEL:SaveSettingsPreset(name) end
 
 vgui.Register("SMHProperties", PANEL, "DFrame")

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -238,6 +238,7 @@ local function AddCallbacks()
         local frame = SMH.State.Frame
 
         PropertiesMenu:SetVisible(true)
+        PropertiesMenu:UpdateTimelineSettings()
         SMH.Controller.GetServerEntities()
 
         if FrameToKeyframe[frame] ~= nil and PropertiesMenu:GetUsingWorld() then
@@ -351,13 +352,17 @@ local function AddCallbacks()
     PropertiesMenu.OnUpdateKeyframeColorRequested = function(_, color, timeline)
         SMH.Controller.UpdateKeyframeColor(color, timeline)
     end
-
     PropertiesMenu.SelectWorld = function()
         SMH.Controller.SelectEntity(LocalPlayer())
     end
-
     PropertiesMenu.SetData = function(_, str, key)
         SMH.Controller.UpdateWorld(str, key)
+    end
+    PropertiesMenu.SetSettings = function(_, settings, presetname)
+        SMH.Controller.SetTimeline(settings, presetname)
+    end
+    PropertiesMenu.SaveSettingsPreset = function(_, name)
+        SMH.Controller.RequestTimelineInfo(name)
     end
 
 end
@@ -403,6 +408,7 @@ hook.Add("InitPostEntity", "SMHMenuSetup", function()
     AddCallbacks()
 
     SMH.Controller.RequestModifiers() -- needed to initialize properties menu
+    PropertiesMenu:InitTimelineSettings()
 
     WorldClicker.MainMenu:SetInitialState(SMH.State)
 
@@ -743,9 +749,16 @@ function MGR.InitModifiers(list)
     PropertiesMenu:InitModifiers(list)
 end
 
+function MGR.RefreshTimelineSettings()
+    PropertiesMenu:UpdateTimelineSettings()
+end
+
 function MGR.SetTimeline(timeline)
     WorldClicker.MainMenu:UpdateTimelines(timeline)
     PropertiesMenu:UpdateTimelineInfo(timeline)
+    if IsValid(SMH.State.Entity) then
+        SMH.Controller.UpdateTimeline()
+    end
 end
 
 function MGR.UpdateState(newState)

--- a/lua/smh/server/ghosts_manager.lua
+++ b/lua/smh/server/ghosts_manager.lua
@@ -122,20 +122,19 @@ function MGR.UpdateState(player, frame, settings, settimeline)
     end
 
     local alpha = settings.GhostTransparency * 255
+    local timeline = SMH.PropertiesManager.GetTimelinesInfo(player)
+    local selectedtime  = settimeline
+    if selectedtime > timeline.Timelines then -- this shouldn't really happen?
+        selectedtime = 1
+    end
+
+    local filtermods = {}
+
+    for _, name in ipairs(timeline.TimelineMods[selectedtime]) do
+        filtermods[name] = true
+    end
 
     for entity, keyframes in pairs(entities) do
-        local timeline = SMH.PropertiesManager.GetAllEntityProperties(player, entity)
-        if next(timeline) == nil then continue end
-        local selectedtime  = settimeline
-        if selectedtime > timeline.Timelines then
-            selectedtime = 1
-        end
-
-        local filtermods = {}
-
-        for _, name in ipairs(timeline.TimelineMods[selectedtime]) do
-            filtermods[name] = true
-        end
 
         for name, _ in pairs(filtermods) do -- gonna apply used modifiers
             local prevKeyframe, nextKeyframe, lerpMultiplier = SMH.GetClosestKeyframes(keyframes, frame, true, name)
@@ -202,7 +201,6 @@ function MGR.UpdateState(player, frame, settings, settimeline)
                     end
                 end
             end
-
         end
 
         ClearNoPhysGhosts(ghosts) -- need to delete ragdoll ghosts that don't have physbone modifier, or else they'll just keep falling through ground.

--- a/lua/smh/server/keyframe_manager.lua
+++ b/lua/smh/server/keyframe_manager.lua
@@ -49,6 +49,9 @@ hook.Add("EntityRemoved", "SMHKeyframesEntityRemoved", function(entity)
             for _, keyframe in pairs(SMH.KeyframeData.Players[player].Entities[entity]) do
                 table.insert(keyframesToDelete, keyframe.ID)
             end
+
+            SMH.KeyframeData.Players[player].Entities[entity] = nil
+
             for _, keyframeId in pairs(keyframesToDelete) do
                 SMH.KeyframeData:Delete(player, keyframeId)
             end
@@ -83,7 +86,7 @@ function MGR.Create(player, entity, frame, timeline)
     local keyframes = {}
 
     if player ~= entity then
-        local modnames = SMH.Properties.Players[player].Entities[entity].TimelineMods[timeline]
+        local modnames = SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline]
         local keyframe = GetExistingKeyframe(player, entity, frame)
 
         if keyframe ~= nil then
@@ -128,7 +131,7 @@ function MGR.Update(player, keyframeIds, updateData, timeline)
         end
 
         local keyframe = SMH.KeyframeData.Players[player].Keyframes[keyframeId]
-        local modnames = player == keyframe.Entity and {"world"} or SMH.Properties.Players[player].Entities[keyframe.Entity].TimelineMods[timeline]
+        local modnames = player == keyframe.Entity and {"world"} or SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline]
         local updateableFields = {
             "Frame",
             "EaseIn",
@@ -199,7 +202,7 @@ function MGR.Copy(player, keyframeIds, frame, timeline)
         end
 
         local keyframe = SMH.KeyframeData.Players[player].Keyframes[keyframeId]
-        local modnames = player == keyframe.Entity and {"world"} or SMH.Properties.Players[player].Entities[keyframe.Entity].TimelineMods[timeline]
+        local modnames = player == keyframe.Entity and {"world"} or SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline]
 
         local EaseIn, EaseOut, Mods = {}, {}, {}
         for _, name in ipairs(modnames) do
@@ -246,7 +249,7 @@ function MGR.Delete(player, keyframeId, timeline)
     local entity = SMH.KeyframeData.Players[player].Keyframes[keyframeId].Entity
 
     local keyframe = SMH.KeyframeData.Players[player].Keyframes[keyframeId]
-    local modnames = player == keyframe.Entity and {"world"} or SMH.Properties.Players[player].Entities[keyframe.Entity].TimelineMods[timeline]
+    local modnames = player == keyframe.Entity and {"world"} or SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline]
 
     for _, name in ipairs(modnames) do
         ClearModifier(keyframe, name)

--- a/lua/smh/server/physrecord.lua
+++ b/lua/smh/server/physrecord.lua
@@ -6,7 +6,7 @@ local function RecordPhys(player, entities, frame)
     for entity, timeline in pairs(entities) do
         SMH.PropertiesManager.AddEntity(player, entity)
 
-        local totaltimelines = SMH.PropertiesManager.GetTimelines(player, entity)
+        local totaltimelines = SMH.PropertiesManager.GetTimelines(player)
         if timeline > totaltimelines then timeline = 1 end
 
         SMH.KeyframeManager.Create(player, entity, frame, timeline)

--- a/lua/smh/server/properties_manager.lua
+++ b/lua/smh/server/properties_manager.lua
@@ -13,20 +13,20 @@ end
 
 local function SetUniqueName(player, entity, name)
     if SMH.Properties.Players[player].Entities[entity] then
-        usednames[SMH.Properties.Players[player].Entities[entity].Name] = nil -- so we won't consider our own name when sorting
+        usednames[player][SMH.Properties.Players[player].Entities[entity].Name] = nil -- so we won't consider our own name when sorting
     end
 
     for kentity, value in pairs(SMH.Properties.Players[player].Entities) do
         if kentity ~= entity and name == value.Name then -- if there's another entity with our name
-            usednames[value.Name] = true
+            usednames[player][value.Name] = true
             break
         end
     end
 
-    while usednames[name] do
+    while usednames[player][name] do
         name = name .. "I"
     end
-    usednames[name] = true
+    usednames[player][name] = true
     return name
 end
 
@@ -51,14 +51,22 @@ local function FindEntity(player) -- I use this to find entity that doesn't have
     return nil
 end
 
+hook.Add("PlayerInitialSpawn", "SMHInitPlayerProperties", function(player)
+    SMH.Properties.Players[player] = { Entities = {}, TimelineSetting = {} }
+    usednames[player] = {}
+end)
+
+hook.Add("PlayerDisconnected", "SMHDeleteProperties", function(player)
+    SMH.Properties.Players[player] = nil
+    usednames[player] = nil
+end)
+
 hook.Add("EntityRemoved", "SMHPropertiesEntityRemoved", function(entity)
 
     for _, player in pairs(player.GetAll()) do
-        if SMH.Properties.Players[player] and SMH.Properties.Players[player].Entities then
-            if SMH.Properties.Players[player].Entities[entity] then
-                usednames[SMH.Properties.Players[player].Entities[entity].Name] = nil
-                SMH.Properties.Players[player].Entities[entity] = nil
-            end
+        if SMH.Properties.Players[player] and SMH.Properties.Players[player].Entities and SMH.Properties.Players[player].Entities[entity] then
+            usednames[player][SMH.Properties.Players[player].Entities[entity].Name] = nil
+            SMH.Properties.Players[player].Entities[entity] = nil
         end
     end
 
@@ -66,21 +74,12 @@ end)
 
 local MGR = {}
 
-function MGR.GetAllEntityProperties(player, selectedentity)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities or not IsValid(selectedentity) then return {} end
+function MGR.GetTimelinesInfo(player)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].TimelineSetting then return {} end
 
     local info = {}
 
-    for entity, value in pairs(SMH.Properties.Players[player].Entities) do
-        if selectedentity == entity then
-            info = {
-                Name = value.Name,
-                Timelines = value.Timelines,
-                TimelineMods = table.Copy(value.TimelineMods),
-            }
-            break
-        end
-    end
+    info = table.Copy(SMH.Properties.Players[player].TimelineSetting)
 
     return info
 end
@@ -93,8 +92,6 @@ function MGR.GetAllProperties(player)
     for entity, value in pairs(SMH.Properties.Players[player].Entities) do
         info[entity] = {
             Name = value.Name,
-            Timelines = value.Timelines,
-            TimelineMods = table.Copy(value.TimelineMods),
             Class = value.Class,
             Model = value.Model,
         }
@@ -117,30 +114,22 @@ function MGR.GetAllEntitiesNames(player)
     return info
 end
 
-function MGR.CheckEntity(player, entity)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities or not SMH.Properties.Players[player].Entities[entity] then return true end
-    return false
-end
-
 function MGR.RemoveEntity(player)
     if not SMH.KeyframeData.Players[player] or not SMH.KeyframeData.Players[player].Entities or not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities then return end
     local entity = FindEntity(player)
     if entity then
-        usednames[SMH.Properties.Players[player].Entities[entity].Name] = nil
+        usednames[player][SMH.Properties.Players[player].Entities[entity].Name] = nil
         SMH.Properties.Players[player].Entities[entity] = nil
     end
 end
 
 function MGR.AddEntity(player, entity)
     if not SMH.Properties.Players[player] then
-        SMH.Properties.Players[player] = { Entities = {} }
+        SMH.Properties.Players[player] = { Entities = {}, TimelineSetting = {} }
     end
 
     if not SMH.Properties.Players[player].Entities[entity] then
         if player ~= entity then
-            local template = SMH.Saves.GetPreferences(player)
-            local timelines
-            local timelinemods = {}
             local class = entity:GetClass()
             local model
 
@@ -150,39 +139,18 @@ function MGR.AddEntity(player, entity)
                 model = entity:GetModel()
             end
 
-            if not template then
-                timelines = 1
-
-                timelinemods[1] = { KeyColor = Color(0, 200, 0) }
-
-                for name, mod in pairs(SMH.Modifiers) do
-                    table.insert(timelinemods[1], name)
-                end
-            else
-                timelines = template.Timelines
-
-                timelinemods = table.Copy(template.TimelineMods)
-            end
             SMH.Properties.Players[player].Entities[entity] = {
                 Name = SetUniqueName(player, entity, GetModelName(entity)),
-                Timelines = timelines,
-                TimelineMods = timelinemods,
                 Class = class,
                 Model = model,
             }
         else
-            local timelinemods = {}
-
-            timelinemods[1] = { KeyColor = Color(0, 200, 0) }
-
             SMH.Properties.Players[player].Entities[entity] = {
                 Name = SetUniqueName(player, entity, "world"),
-                Timelines = 1,
-                TimelineMods = timelinemods,
             }
         end
     end
-    usednames[SMH.Properties.Players[player].Entities[entity].Name] = true
+    usednames[player][SMH.Properties.Players[player].Entities[entity].Name] = true
 end
 
 function MGR.SetName(player, entity, newname)
@@ -195,10 +163,37 @@ function MGR.SetName(player, entity, newname)
     return newname
 end
 
-function MGR.SetTimelines(player, entity, add)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+function MGR.InitTimelineSetting(player, timelineInfo)
+    if not SMH.Properties.Players[player] then
+        SMH.Properties.Players[player] = { Entities = {}, TimelineSetting = {} }
+    end
 
-    local timelines = SMH.Properties.Players[player].Entities[entity].Timelines
+    local timelines
+    local timelinemods = {}
+
+    if not next(timelineInfo) then
+        timelines = 1
+
+        timelinemods[1] = { KeyColor = Color(0, 200, 0) }
+        for name, mod in pairs(SMH.Modifiers) do
+            table.insert(timelinemods[1], name)
+        end
+    else
+        timelines = timelineInfo.Timelines
+
+        timelinemods = table.Copy(timelineInfo.TimelineMods)
+    end
+
+    SMH.Properties.Players[player].TimelineSetting = {
+        Timelines = timelines,
+        TimelineMods = timelinemods
+    }
+end
+
+function MGR.SetTimelines(player, add)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].TimelineSetting then return end
+
+    local timelines = SMH.Properties.Players[player].TimelineSetting.Timelines
     local count
     if add then
         count = timelines + 1
@@ -209,39 +204,39 @@ function MGR.SetTimelines(player, entity, add)
     if count > 10 or count < 1 then return end  -- just in case
 
     if add then
-        SMH.Properties.Players[player].Entities[entity].TimelineMods[count] = { KeyColor = Color(0, 200, 0) }
+        SMH.Properties.Players[player].TimelineSetting.TimelineMods[count] = { KeyColor = Color(0, 200, 0) }
     else
-        SMH.Properties.Players[player].Entities[entity].TimelineMods[timelines] = nil
+        SMH.Properties.Players[player].TimelineSetting.TimelineMods[timelines] = nil
     end
 
-    SMH.Properties.Players[player].Entities[entity].Timelines = count
+    SMH.Properties.Players[player].TimelineSetting.Timelines = count
 end
 
-function MGR.UpdateModifier(player, entity, itimeline, name, state)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+function MGR.UpdateModifier(player, itimeline, name, state)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].TimelineSetting then return end
 
     if state then 
-        table.insert(SMH.Properties.Players[player].Entities[entity].TimelineMods[itimeline], name)
-        for i = 1, SMH.Properties.Players[player].Entities[entity].Timelines do
+        table.insert(SMH.Properties.Players[player].TimelineSetting.TimelineMods[itimeline], name)
+        for i = 1, SMH.Properties.Players[player].TimelineSetting.Timelines do
             if i == itimeline then continue end
-            table.RemoveByValue(SMH.Properties.Players[player].Entities[entity].TimelineMods[i], name)
+            table.RemoveByValue(SMH.Properties.Players[player].TimelineSetting.TimelineMods[i], name)
         end
     else
-        table.RemoveByValue(SMH.Properties.Players[player].Entities[entity].TimelineMods[itimeline], name)
+        table.RemoveByValue(SMH.Properties.Players[player].TimelineSetting.TimelineMods[itimeline], name)
     end
 
     return name
 end
 
-function MGR.UpdateKeyframeColor(player, entity, color, timeline)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return end
+function MGR.UpdateKeyframeColor(player, color, timeline)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].TimelineSetting then return end
 
-    SMH.Properties.Players[player].Entities[entity].TimelineMods[timeline].KeyColor = color
+    SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline].KeyColor = color
 end
 
-function MGR.GetTimelines(player, entity)
-    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].Entities[entity] then return 1 end
-    return SMH.Properties.Players[player].Entities[entity].Timelines
+function MGR.GetTimelines(player)
+    if not SMH.Properties.Players[player] or not SMH.Properties.Players[player].TimelineSetting then return 1 end
+    return SMH.Properties.Players[player].TimelineSetting.Timelines
 end
 
 function MGR.SetProperties(player, entity, properties)
@@ -249,8 +244,6 @@ function MGR.SetProperties(player, entity, properties)
 
     local newname = SetUniqueName(player, entity, properties.Name)
     SMH.Properties.Players[player].Entities[entity].Name = newname
-    SMH.Properties.Players[player].Entities[entity].Timelines = properties.Timelines
-    SMH.Properties.Players[player].Entities[entity].TimelineMods = properties.TimelineMods
 end
 
 SMH.PropertiesManager = MGR

--- a/lua/smh/shared.lua
+++ b/lua/smh/shared.lua
@@ -65,7 +65,9 @@ SMH.MessageTypes = {
     "OffsetPos",
     "OffsetAng",
 
-    "SaveProperties",
+    "SetTimeline",
+    "RequestTimelineInfo",
+    "RequestTimelineInfoResponse",
 
     "RequestWorldData",
     "RequestWorldDataResponse",

--- a/lua/smh/shared/tablesplit.lua
+++ b/lua/smh/shared/tablesplit.lua
@@ -46,7 +46,7 @@ end
 
 function MGR.DProperties(timeline)
     if not next(timeline) then return end
-    local Name, Timelines = timeline.Name, timeline.Timelines
+    local Timelines = timeline.Timelines
     local KeyColor, Modifiers, ModCount = {}, {}, {}
 
     for key, _ in ipairs(timeline.TimelineMods) do
@@ -62,11 +62,10 @@ function MGR.DProperties(timeline)
             Modifiers[key][k] = value
         end
     end
-    return Name, Timelines, KeyColor, ModCount, Modifiers
+    return Timelines, KeyColor, ModCount, Modifiers
 end
 
-function MGR.StartAProperties(Name, Timelines)
-    timelineAssembling.Name = Name
+function MGR.StartAProperties(Timelines)
     timelineAssembling.Timelines = Timelines
     timelineAssembling.TimelineMods = {}
     return Timelines


### PR DESCRIPTION
- Timelines are now bound to players, so there is no need to set new timeline settings for every new entity you record.
- Added an option to save and load timeline presets and swap them through properties window. Probably in the future I'll add an option to quickly swap timeline presets through main smh menu.
- Due to above changes, smh_savepreset command was removed due to being not needed. (previously saved default timeline preset will be available through properties window as those presets share same folder)
- Small tweak: deleting entities will properly clean up its frames
- Custom entity names for smh should work properly in multiplayer if they didn't work before, I didn't test how it was before but now it should work anyway