### PR TITLE
Multi entity selection

### DIFF
--- a/lua/smh/client/derma/physrecord.lua
+++ b/lua/smh/client/derma/physrecord.lua
@@ -53,20 +53,23 @@ function PANEL:Init()
         SMH.PhysRecord.RecordToggle()
         self.SelectEntity:SetText("Select Entity")
 
-        if not IsValid(SMH.State.Entity) then return end
-        SMH.PhysRecord.SelectedEntities[SMH.State.Entity] = SMH.State.Timeline
+        if not next(SMH.State.Entity) then return end
+        for entity, _ in pairs(SMH.State.Entity) do
+            SMH.PhysRecord.SelectedEntities[entity] = SMH.State.Timeline
+        end
     end
 
     self.SelectEntity = vgui.Create("DButton", self)
     self.SelectEntity:SetText("Select Entity")
     self.SelectEntity.DoClick = function()
-        if not IsValid(SMH.State.Entity) then return end
+        if not next(SMH.State.Entity) then return end
+        local entity = next(SMH.State.Entity)
 
-        if not SMH.PhysRecord.SelectedEntities[SMH.State.Entity] then
-            SMH.PhysRecord.SelectedEntities[SMH.State.Entity] = SMH.State.Timeline
+        if not SMH.PhysRecord.SelectedEntities[entity] then
+            SMH.PhysRecord.SelectedEntities[entity] = SMH.State.Timeline
             self.SelectEntity:SetText("Unselect Entity")
         else
-            SMH.PhysRecord.SelectedEntities[SMH.State.Entity] = nil
+            SMH.PhysRecord.SelectedEntities[entity] = nil
             self.SelectEntity:SetText("Select Entity")
         end
     end

--- a/lua/smh/client/derma/world_clicker.lua
+++ b/lua/smh/client/derma/world_clicker.lua
@@ -32,9 +32,12 @@ function PANEL:OnMousePressed(mousecode)
     local trace = util.TraceLine(util.GetPlayerTrace(LocalPlayer()))
     if not IsValid(trace.Entity) then return end
 
-    self:OnEntitySelected(trace.Entity)
+    local setting = 0
+    if input.IsKeyDown(KEY_LSHIFT) then setting = 1 end
+
+    self:OnEntitySelected(trace.Entity, setting)
 end
 
-function PANEL:OnEntitySelected(entity) end
+function PANEL:OnEntitySelected(entity, setting) end
 
 vgui.Register("SMHWorldClicker", PANEL, "EditablePanel")

--- a/lua/smh/client/highlighter.lua
+++ b/lua/smh/client/highlighter.lua
@@ -5,7 +5,7 @@ local mat_Add    = Material( "pp/add" )
 local mat_Sub    = Material( "pp/sub" )
 local rt_Stencil    = render.GetBloomTex0()
 local rt_Store        = render.GetScreenEffectTexture( 0 )
-local function RenderHalo(entity)
+local function RenderHalo(entities)
 
     local OldRT = render.GetRenderTarget()
 
@@ -24,45 +24,53 @@ local function RenderHalo(entity)
         cam.IgnoreZ( false )
         render.OverrideDepthEnable( true, false )                                    -- Don't write depth
 
-        render.SetStencilEnable( true );
-        render.SetStencilFailOperation( STENCILOPERATION_KEEP );
-        render.SetStencilZFailOperation( STENCILOPERATION_KEEP );
-        render.SetStencilPassOperation( STENCILOPERATION_REPLACE );
-        render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_ALWAYS );
-        render.SetStencilWriteMask( 1 );
-        render.SetStencilReferenceValue( 1 );
+        render.SetStencilEnable( true )
+        render.SetStencilFailOperation( STENCILOPERATION_KEEP )
+        render.SetStencilZFailOperation( STENCILOPERATION_KEEP )
+        render.SetStencilPassOperation( STENCILOPERATION_REPLACE )
+        render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_ALWAYS )
+        render.SetStencilWriteMask( 1 )
+        render.SetStencilReferenceValue( 1 )
 
-        render.SetBlend( 0 ); -- don't render any colour
+        render.SetBlend( 0 ) -- don't render any colour
 
         render.PushFlashlightMode( true )
-        entity:DrawModel()
+        for entity, _ in pairs(entities) do
+            if IsValid(entity) then
+                entity:DrawModel()
+            end
+        end
         render.PopFlashlightMode()
 
     cam.End3D()
 
     -- FILL COLOUR
     -- Write to the colour buffer
-    cam.Start3D( EyePos(), EyeAngles() );
+    cam.Start3D( EyePos(), EyeAngles() )
 
-        render.MaterialOverride( matColor )    ;
+        render.MaterialOverride( matColor )
         cam.IgnoreZ( false );
 
-        render.SetStencilEnable( true );
-        render.SetStencilWriteMask( 0 );
-        render.SetStencilReferenceValue( 0 );
-        render.SetStencilTestMask( 1 );
-        render.SetStencilFailOperation( STENCILOPERATION_KEEP );
-        render.SetStencilPassOperation( STENCILOPERATION_KEEP );
-        render.SetStencilZFailOperation( STENCILOPERATION_KEEP );
-        render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_NOTEQUAL );
+        render.SetStencilEnable( true )
+        render.SetStencilWriteMask( 0 )
+        render.SetStencilReferenceValue( 0 )
+        render.SetStencilTestMask( 1 )
+        render.SetStencilFailOperation( STENCILOPERATION_KEEP )
+        render.SetStencilPassOperation( STENCILOPERATION_KEEP )
+        render.SetStencilZFailOperation( STENCILOPERATION_KEEP )
+        render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_NOTEQUAL )
 
-        render.SetColorModulation(0, 1, 0);
-        render.SetBlend(1);
+        render.SetColorModulation(0, 1, 0)
+        render.SetBlend(1)
 
-        entity:DrawModel();
+        for entity, _ in pairs(entities) do
+            if IsValid(entity) then
+                entity:DrawModel()
+            end
+        end
 
-        render.MaterialOverride(nil);
-        render.SetStencilEnable(false);
+        render.MaterialOverride(nil)
+        render.SetStencilEnable(false)
 
     cam.End3D()
 
@@ -73,49 +81,49 @@ local function RenderHalo(entity)
     render.BlurRenderTarget( rt_Stencil, 2, 2, 1 )
 
     -- Put our scene back
-    render.SetRenderTarget( OldRT );
-    render.SetColorModulation( 1, 1, 1 );
-    render.SetStencilEnable( false );
-    render.OverrideDepthEnable( true, false );
-    render.SetBlend( 1 );
-    mat_Copy:SetTexture( "$basetexture", rt_Store );
-    render.SetMaterial( mat_Copy );
-    render.DrawScreenQuad();
+    render.SetRenderTarget( OldRT )
+    render.SetColorModulation( 1, 1, 1 )
+    render.SetStencilEnable( false )
+    render.OverrideDepthEnable( true, false )
+    render.SetBlend( 1 )
+    mat_Copy:SetTexture( "$basetexture", rt_Store )
+    render.SetMaterial( mat_Copy )
+    render.DrawScreenQuad()
 
 
     -- DRAW IT TO THE SCEEN
 
-    render.SetStencilEnable( true );
-    render.SetStencilWriteMask( 0 );
-    render.SetStencilReferenceValue( 0 );
-    render.SetStencilTestMask( 1 );
-    render.SetStencilFailOperation( STENCILOPERATION_KEEP );
-    render.SetStencilPassOperation( STENCILOPERATION_KEEP );
-    render.SetStencilZFailOperation( STENCILOPERATION_KEEP );
-    render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_EQUAL );
+    render.SetStencilEnable( true )
+    render.SetStencilWriteMask( 0 )
+    render.SetStencilReferenceValue( 0 )
+    render.SetStencilTestMask( 1 )
+    render.SetStencilFailOperation( STENCILOPERATION_KEEP )
+    render.SetStencilPassOperation( STENCILOPERATION_KEEP )
+    render.SetStencilZFailOperation( STENCILOPERATION_KEEP )
+    render.SetStencilCompareFunction( STENCILCOMPARISONFUNCTION_EQUAL )
 
-    mat_Add:SetTexture( "$basetexture", rt_Stencil );
-    render.SetMaterial( mat_Add );
+    mat_Add:SetTexture( "$basetexture", rt_Stencil )
+    render.SetMaterial( mat_Add )
 
     for i=0, 2 do
-        render.DrawScreenQuad();
+        render.DrawScreenQuad()
     end
 
     -- PUT EVERYTHING BACK HOW WE FOUND IT
 
-    render.SetStencilWriteMask( 0 );
-    render.SetStencilReferenceValue( 0 );
-    render.SetStencilTestMask( 0 );
-    render.SetStencilEnable( false );
-    render.OverrideDepthEnable( false );
-    render.SetBlend( 1 );
+    render.SetStencilWriteMask( 0 )
+    render.SetStencilReferenceValue( 0 )
+    render.SetStencilTestMask( 0 )
+    render.SetStencilEnable( false )
+    render.OverrideDepthEnable( false )
+    render.SetBlend( 1 )
 
-    cam.IgnoreZ( false );
+    cam.IgnoreZ( false )
 
 end
 
 hook.Add("PostDrawEffects", "smh_highlighter", function()
-    if not IsValid(SMH.State.Entity) or not SMH.Controller.ShouldHighlight() then
+    if not next(SMH.State.Entity) or not SMH.Controller.ShouldHighlight() then
         return
     end
 

--- a/lua/smh/client/physrecord.lua
+++ b/lua/smh/client/physrecord.lua
@@ -28,7 +28,7 @@ MGR.SelectedEntities = {}
 function MGR.RecordToggle()
 
     if not Active then
-        SMH.Controller.SelectEntity(nil)
+        SMH.Controller.SelectEntity(nil, {})
         Active = true
         local wait = MGR.StartDelay
         Waiting = wait

--- a/lua/smh/client/state.lua
+++ b/lua/smh/client/state.lua
@@ -1,5 +1,5 @@
 SMH.State = {
-    Entity = nil,
+    Entity = {},
     Frame = 0,
     Timeline = 1,
 

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -569,7 +569,7 @@ function MGR.UpdateKeyframe(keyframe)
         --     WorldClicker.MainMenu.FramePanel:DeleteFramePointer(pointer)
         -- end
     end
-    local name = next(keyframe.Modifiers)
+    local _, name = next(PropertiesMenu:GetCurrentModifiers())
 
     KeyframeEasingData[KeyframeIDs[keyframe.ID]] = {
         EaseIn = keyframe.EaseIn[name],

--- a/lua/smh/server/controller.lua
+++ b/lua/smh/server/controller.lua
@@ -292,11 +292,11 @@ local function Load(msgLength, player)
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.LoadResponse)
-    framecount = SendKeyframes(framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    framecount = SendKeyframes(framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
     net.WriteEntity(entity)
     net.Send(player)
 
-    SendLeftoverKeyframes(player, framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    SendLeftoverKeyframes(player, framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
 end
 
 local function GetModelInfo(msgLength, player)
@@ -366,10 +366,10 @@ local function UpdateTimeline(msgLength, player)
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.UpdateTimelineResponse)
-    framecount = SendKeyframes(framecount, IDs, entities, Frame, In, Out, KModCount, KModifiers)
+    framecount = SendKeyframes(framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
     net.Send(player)
 
-    SendLeftoverKeyframes(player, framecount, IDs, entities, Frame, In, Out, KModCount, KModifiers)
+    SendLeftoverKeyframes(player, framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
 end
 
 local function RequestModifiers(msgLength, player)
@@ -504,10 +504,10 @@ local function SpawnEntity(msgLength, player)
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.LoadResponse)
-    framecount = SendKeyframes(framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    framecount = SendKeyframes(framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
     net.Send(player)
 
-    SendLeftoverKeyframes(player, framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    SendLeftoverKeyframes(player, framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
 end
 
 local function SpawnReset(msgLength, player)

--- a/lua/smh/server/controller.lua
+++ b/lua/smh/server/controller.lua
@@ -5,11 +5,11 @@ local function SendKeyframes(framecount, IDs, ents, Frame, In, Out, ModCount, Mo
     if not loop then loop = 0 end
 
     local sendframes = framecount > KFRAMES_PER_MSG and KFRAMES_PER_MSG or framecount
-    net.WriteEntity(ents)
 
     net.WriteUInt(sendframes, INT_BITCOUNT)
     for i = 1 + KFRAMES_PER_MSG * loop, sendframes + KFRAMES_PER_MSG * loop do
         net.WriteUInt(IDs[i],INT_BITCOUNT)
+        net.WriteEntity(ents[i])
         net.WriteUInt(Frame[i], INT_BITCOUNT)
         net.WriteUInt(ModCount[i], INT_BITCOUNT)
         for j = 1, ModCount[i] do
@@ -43,13 +43,13 @@ local function ReceiveProperties()
     return SMH.TableSplit.GetProperties()
 end
 
-local function SendLeftoverKeyframes(player, framecount, IDs, entity, Frame, In, Out, ModCount, Modifiers)
+local function SendLeftoverKeyframes(player, framecount, IDs, entities, Frame, In, Out, ModCount, Modifiers)
     if framecount < 0 then return end
 
     for i = 1, math.ceil(framecount / KFRAMES_PER_MSG) do
         if framecount < 0 then break end
         net.Start(SMH.MessageTypes.GetAllKeyframes)
-            framecount = SendKeyframes(framecount, IDs, entity, Frame, In, Out, ModCount, Modifiers, i)
+            framecount = SendKeyframes(framecount, IDs, entities, Frame, In, Out, ModCount, Modifiers, i)
         net.Send(player)
     end
 end
@@ -69,37 +69,50 @@ end
 
 local function SelectEntity(msgLength, player)
     local entity = net.ReadEntity()
+    local entities = {}
 
     if entity.SMHGhost then
         entity = entity.Entity
     end
 
-    if player ~= entity then
-        SMH.GhostsManager.SelectEntity(player, entity)
-    else
-        SMH.GhostsManager.SelectEntity(player, nil)
+    for i = 1, net.ReadUInt(INT_BITCOUNT) do
+        entities[i] = net.ReadEntity()
     end
 
-    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entity)
+    if player ~= entity then
+        SMH.GhostsManager.SelectEntity(player, entities)
+    else
+        SMH.GhostsManager.SelectEntity(player, {})
+    end
+
+    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entities)
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.SelectEntityResponse)
-    framecount = SendKeyframes(framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    framecount = SendKeyframes(framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
+    net.WriteUInt(#entities, INT_BITCOUNT)
+    for _, entity in ipairs(entities) do
+        net.WriteEntity(entity)
+    end
     net.Send(player)
 
-    SendLeftoverKeyframes(player, framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    SendLeftoverKeyframes(player, framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers)
 end
 
 local function CreateKeyframe(msgLength, player)
-    local entity = net.ReadEntity()
+    local entities = {}
+    for i = 1, net.ReadUInt(INT_BITCOUNT) do
+        entities[i] = net.ReadEntity()
+    end
+
     local frame = net.ReadUInt(INT_BITCOUNT)
     local timeline = net.ReadUInt(INT_BITCOUNT)
 
-    SMH.PropertiesManager.AddEntity(player, entity)
+    SMH.PropertiesManager.AddEntity(player, entities)
     local totaltimelines = SMH.PropertiesManager.GetTimelines(player)
     if timeline > totaltimelines then timeline = 1 end
 
-    local keyframes = SMH.KeyframeManager.Create(player, entity, frame, timeline)
+    local keyframes = SMH.KeyframeManager.Create(player, entities, frame, timeline)
     if not next(keyframes) then return end
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
@@ -272,14 +285,15 @@ local function Load(msgLength, player)
 
     if isWorld then entity = player end
 
-    SMH.PropertiesManager.AddEntity(player, entity)
+    SMH.PropertiesManager.AddEntity(player, {entity})
     SMH.KeyframeManager.ImportSave(player, entity, serializedKeyframes, entityProperties)
 
-    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entity)
+    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, {entity})
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.LoadResponse)
     framecount = SendKeyframes(framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    net.WriteEntity(entity)
     net.Send(player)
 
     SendLeftoverKeyframes(player, framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
@@ -343,16 +357,19 @@ local function ApplyEntityName(msgLength, player)
 end
 
 local function UpdateTimeline(msgLength, player)
-    local entity = net.ReadEntity()
+    local entities = {}
+    for i = 1, net.ReadUInt(INT_BITCOUNT) do
+        entities[i] = net.ReadEntity()
+    end
 
-    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entity)
+    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entities)
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.UpdateTimelineResponse)
-    framecount = SendKeyframes(framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    framecount = SendKeyframes(framecount, IDs, entities, Frame, In, Out, KModCount, KModifiers)
     net.Send(player)
 
-    SendLeftoverKeyframes(player, framecount, IDs, entity, Frame, In, Out, KModCount, KModifiers)
+    SendLeftoverKeyframes(player, framecount, IDs, entities, Frame, In, Out, KModCount, KModifiers)
 end
 
 local function RequestModifiers(msgLength, player)
@@ -476,14 +493,14 @@ local function SpawnEntity(msgLength, player)
 
     serializedKeyframes, entityProperties = SMH.Saves.LoadForEntity(path, modelName)
 
-    SMH.PropertiesManager.AddEntity(player, entity)
+    SMH.PropertiesManager.AddEntity(player, {entity})
     SMH.KeyframeManager.ImportSave(player, entity, serializedKeyframes, entityProperties)
 
     if offset then
         SMH.Spawner.OffsetKeyframes(player, entity)
     end
 
-    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, entity)
+    local keyframes = SMH.KeyframeManager.GetAllForEntity(player, {entity})
     local framecount, IDs, ents, Frame, In, Out, KModCount, KModifiers = SMH.TableSplit.DKeyframes(keyframes)
 
     net.Start(SMH.MessageTypes.LoadResponse)
@@ -544,19 +561,20 @@ local function StartPhysicsRecord(msgLength, player)
     local frame = net.ReadUInt(INT_BITCOUNT)
     local playbackrate = net.ReadUInt(INT_BITCOUNT)
     local totalframes = net.ReadUInt(INT_BITCOUNT)
-    local entities = {}
+    local entities, timelines = {}, {}
 
     for i = 1, net.ReadUInt(INT_BITCOUNT) do
         local entity = net.ReadEntity()
         local timeline = net.ReadUInt(INT_BITCOUNT)
 
         if not IsValid(entity) then continue end
-        entities[entity] = timeline
+        entities[i] = entity
+        timelines[entity] = timeline
     end
 
     local settings = net.ReadTable()
 
-    SMH.PhysRecord.RecordStart(player, framecount, interval, frame, playbackrate, totalframes, entities, settings)
+    SMH.PhysRecord.RecordStart(player, framecount, interval, frame, playbackrate, totalframes, entities, timelines, settings)
 end
 
 local function StopPhysicsRecord(msgLength, player)

--- a/lua/smh/server/ghosts_manager.lua
+++ b/lua/smh/server/ghosts_manager.lua
@@ -76,15 +76,15 @@ local MGR = {}
 
 MGR.IsRendering = false
 
-function MGR.SelectEntity(player, entity)
+function MGR.SelectEntity(player, entities)
     if not GhostData[player] then
         GhostData[player] = {
-            Entity = nil,
+            Entity = {},
             Ghosts = {},
         }
     end
 
-    GhostData[player].Entity = entity
+    GhostData[player].Entity = table.Copy(entities)
 end
 
 function MGR.UpdateState(player, frame, settings, settimeline)
@@ -113,10 +113,13 @@ function MGR.UpdateState(player, frame, settings, settimeline)
     end
 
     local entities = SMH.KeyframeData.Players[player].Entities
-    if not settings.GhostAllEntities and IsValid(GhostData[player].Entity) and entities[GhostData[player].Entity] then
-        entities = {
-            [GhostData[player].Entity] = entities[GhostData[player].Entity]
-        }
+    local _, gentity = next(GhostData[player].Entity)
+    if not settings.GhostAllEntities and IsValid(gentity) and entities[gentity] then
+        local oldentities = table.Copy(entities)
+        entities = {}
+        for _, entity in pairs(GhostData[player].Entity) do
+            entities[entity] = oldentities[entity]
+        end
     elseif not settings.GhostAllEntities then
         return
     end

--- a/lua/smh/server/keyframe_manager.lua
+++ b/lua/smh/server/keyframe_manager.lua
@@ -75,48 +75,59 @@ function MGR.GetAll(player)
     return result
 end
 
-function MGR.GetAllForEntity(player, entity)
-    if not SMH.KeyframeData.Players[player] or not SMH.KeyframeData.Players[player].Entities[entity] then
-        return {}
-    end
-    return table.Copy(SMH.KeyframeData.Players[player].Entities[entity])
-end
-
-function MGR.Create(player, entity, frame, timeline)
+function MGR.GetAllForEntity(player, entities)
     local keyframes = {}
 
-    if player ~= entity then
-        local modnames = SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline]
-        local keyframe = GetExistingKeyframe(player, entity, frame)
+    for _, entity in ipairs(entities) do
+        if not SMH.KeyframeData.Players[player] or not SMH.KeyframeData.Players[player].Entities[entity] then
+            continue
+        end
 
-        if keyframe ~= nil then
-            local check = Record(keyframe, player, entity, modnames)
-            if check then
-                table.insert(keyframes, keyframe)
+        for k, keyframe in pairs(SMH.KeyframeData.Players[player].Entities[entity]) do
+            table.insert(keyframes, keyframe)
+        end
+    end
+
+    return keyframes
+end
+
+function MGR.Create(player, entities, frame, timeline)
+    local keyframes = {}
+
+    for _, entity in ipairs(entities) do
+        if player ~= entity then
+            local modnames = SMH.Properties.Players[player].TimelineSetting.TimelineMods[timeline]
+            local keyframe = GetExistingKeyframe(player, entity, frame)
+
+            if keyframe ~= nil then
+                local check = Record(keyframe, player, entity, modnames)
+                if check then
+                    table.insert(keyframes, keyframe)
+                end
+            else
+                keyframe = SMH.KeyframeData:New(player, entity)
+                keyframe.Frame = frame
+                local check = Record(keyframe, player, entity, modnames)
+                if check then
+                    table.insert(keyframes, keyframe)
+                end
             end
         else
+            local keyframe = GetExistingKeyframe(player, entity, frame, {"world"})
+
+            if keyframe ~= nil then return {keyframe} end
+
             keyframe = SMH.KeyframeData:New(player, entity)
             keyframe.Frame = frame
-            local check = Record(keyframe, player, entity, modnames)
-            if check then
-                table.insert(keyframes, keyframe)
-            end
+            keyframe.EaseIn["world"] = 0
+            keyframe.EaseOut["world"] = 0
+            keyframe.Modifiers["world"] = {
+                Console = "",
+                Push = "",
+                Release = "",
+            }
+            table.insert(keyframes, keyframe)
         end
-    else
-        local keyframe = GetExistingKeyframe(player, entity, frame, {"world"})
-
-        if keyframe ~= nil then return {keyframe} end
-
-        keyframe = SMH.KeyframeData:New(player, entity)
-        keyframe.Frame = frame
-        keyframe.EaseIn["world"] = 0
-        keyframe.EaseOut["world"] = 0
-        keyframe.Modifiers["world"] = {
-            Console = "",
-            Push = "",
-            Release = "",
-        }
-        table.insert(keyframes, keyframe)
     end
 
     return keyframes

--- a/lua/smh/server/physrecord.lua
+++ b/lua/smh/server/physrecord.lua
@@ -2,38 +2,38 @@ local SMHRecorderID = "SMH_Recording_Timer"
 
 local MGR = {}
 
-local function RecordPhys(player, entities, frame)
-    for entity, timeline in pairs(entities) do
-        SMH.PropertiesManager.AddEntity(player, entity)
+local function RecordPhys(player, entities, timelines, frame)
+    SMH.PropertiesManager.AddEntity(player, entities)
 
+    for _, entity in ipairs(entities) do
         local totaltimelines = SMH.PropertiesManager.GetTimelines(player)
-        if timeline > totaltimelines then timeline = 1 end
+        if timelines[entity] > totaltimelines then timelines[entity] = 1 end
 
-        SMH.KeyframeManager.Create(player, entity, frame, timeline)
+        SMH.KeyframeManager.Create(player, {entity}, frame, timelines[entity])
     end
 end
 
-function MGR.RecordStart(player, framecount, interval, frame, playbackrate, endframe, entities, settings)
+function MGR.RecordStart(player, framecount, interval, frame, playbackrate, endframe, entities, timelines, settings)
     if framecount < 3 then framecount = 3 end
     if interval < 0 then interval = 0 end
     local counter = -1
-    RecordPhys(player, entities, frame)
+    RecordPhys(player, entities, timelines, frame)
 
     timer.Create(SMHRecorderID .. player:EntIndex(), 1 / playbackrate , framecount, function()
         counter = counter + 1
 
         if interval == 0 or (counter / interval) == math.Round(counter / interval)  then 
-            RecordPhys(player, entities, frame)
+            RecordPhys(player, entities, timelines, frame)
         end
 
         if counter >= framecount - 1 or frame + 1 > endframe - 1  then
-            RecordPhys(player, entities, frame)
+            RecordPhys(player, entities, timelines, frame)
             timer.Remove(SMHRecorderID .. player:EntIndex())
             player:ChatPrint( "SMH Physics Recorder stopped.")
             SMH.Controller.StopPhysicsRecordResponse(player)
         else
             frame = frame + 1
-            SMH.PlaybackManager.SetFrameIgnore(player, frame, settings, entities)
+            SMH.PlaybackManager.SetFrameIgnore(player, frame, settings, timelines)
         end
     end)
 

--- a/lua/smh/server/properties_manager.lua
+++ b/lua/smh/server/properties_manager.lua
@@ -123,34 +123,36 @@ function MGR.RemoveEntity(player)
     end
 end
 
-function MGR.AddEntity(player, entity)
+function MGR.AddEntity(player, entities)
     if not SMH.Properties.Players[player] then
         SMH.Properties.Players[player] = { Entities = {}, TimelineSetting = {} }
     end
 
-    if not SMH.Properties.Players[player].Entities[entity] then
-        if player ~= entity then
-            local class = entity:GetClass()
-            local model
+    for _, entity in ipairs(entities) do
+        if not SMH.Properties.Players[player].Entities[entity] then
+            if player ~= entity then
+                local class = entity:GetClass()
+                local model
 
-            if class == "prop_effect" and IsValid(entity.AttachedEntity) then
-                model = entity.AttachedEntity:GetModel()
+                if class == "prop_effect" and IsValid(entity.AttachedEntity) then
+                    model = entity.AttachedEntity:GetModel()
+                else
+                    model = entity:GetModel()
+                end
+
+                SMH.Properties.Players[player].Entities[entity] = {
+                    Name = SetUniqueName(player, entity, GetModelName(entity)),
+                    Class = class,
+                    Model = model,
+                }
             else
-                model = entity:GetModel()
+                SMH.Properties.Players[player].Entities[entity] = {
+                    Name = SetUniqueName(player, entity, "world"),
+                }
             end
-
-            SMH.Properties.Players[player].Entities[entity] = {
-                Name = SetUniqueName(player, entity, GetModelName(entity)),
-                Class = class,
-                Model = model,
-            }
-        else
-            SMH.Properties.Players[player].Entities[entity] = {
-                Name = SetUniqueName(player, entity, "world"),
-            }
         end
+        usednames[player][SMH.Properties.Players[player].Entities[entity].Name] = true
     end
-    usednames[player][SMH.Properties.Players[player].Entities[entity].Name] = true
 end
 
 function MGR.SetName(player, entity, newname)

--- a/lua/smh/shared/tablesplit.lua
+++ b/lua/smh/shared/tablesplit.lua
@@ -5,14 +5,14 @@ local listAssembling = {}
 local MGR = {} -- btw D stands for "deconstruct", A for "Assemble"
 
 function MGR.DKeyframes(keyframes)
-    local IDs, ent, Frame, In, Out, ModCount, Modifiers = {}, {}, {}, {}, {}, {}, {}
+    local IDs, ents, Frame, In, Out, ModCount, Modifiers = {}, {}, {}, {}, {}, {}, {}
     local i = 0
     for _, keyframe in pairs(keyframes) do
         i = i + 1
 
         IDs[i] = keyframe.ID
         Frame[i] = keyframe.Frame
-        ent = keyframe.Entity -- We won't be using keyframes from multiple entities with these functions anyway
+        ents[i] = keyframe.Entity
         Modifiers[i], In[i], Out[i] = {}, {}, {}
         ModCount[i] = 0
         for name, data in pairs(keyframe.Modifiers) do
@@ -23,7 +23,7 @@ function MGR.DKeyframes(keyframes)
         end
     end
 
-    return i, IDs, ent, Frame, In, Out, ModCount, Modifiers
+    return i, IDs, ents, Frame, In, Out, ModCount, Modifiers
 end
 
 function MGR.AKeyframes(ID, entity, Frame, In, Out, Modifiers)


### PR DESCRIPTION
- Added function to select multiple entities and record them at once, whereas also being able to manipulate their keyframes. Select multiple entities by bringing up SMH menu and shift + right click to add entities to selection. It's not possible to deselect specific entities from a selection yet, but right clicking on an entity without shift will select only that entity, effectivaly clearing out the selection. Using physics recorder's "select entity" or loading animations from a save onto multiple entities doesn't work correctly, as it will only apply whatever it does to the entity with lowest ID. Starting recording with physics recorder however will start recording all the entities you had selected anyway
- Fixed an issue related to not correctly sending keyframes from server to client, which was causing issues