### PR TITLE
Small tweaks

### DIFF
--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -303,6 +303,10 @@ function CTRL.UpdateSettings(newSettings)
     SMH.Settings.Update(newSettings)
 end
 
+function CTRL.UpdateUISetting(setting, value)
+    SMH.UI.UpdateUISetting(setting, value)
+end
+
 function CTRL.OpenHelp()
     gui.OpenURL("https://github.com/Winded/StopMotionHelper/blob/master/TUTORIAL.md")
 end

--- a/lua/smh/client/derma/physrecord.lua
+++ b/lua/smh/client/derma/physrecord.lua
@@ -5,7 +5,18 @@ function PANEL:Init()
     local function CreateSlider(label, min, max, default, func)
         local slider = vgui.Create("DNumSlider", self)
 
-        slider.ValueChanged = function(self, val) -- overriding default function as it used to clamp result between mix and max, and we kinda want to go over the max if need be
+        -- overriding default functions as it used to clamp result between mix and max, and we kinda want to go over the max if need be
+        slider.SetValue = function(self, val)
+
+            if ( self:GetValue() == val ) then return end
+
+            self.Scratch:SetValue( val )
+
+            self:ValueChanged( self:GetValue() )
+
+        end
+
+        slider.ValueChanged = function(self, val)
 
             if ( self.TextArea != vgui.GetKeyboardFocus() ) then
                 self.TextArea:SetValue( self.Scratch:GetTextValue() )

--- a/lua/smh/client/derma/physrecord.lua
+++ b/lua/smh/client/derma/physrecord.lua
@@ -4,6 +4,19 @@ function PANEL:Init()
 
     local function CreateSlider(label, min, max, default, func)
         local slider = vgui.Create("DNumSlider", self)
+
+        slider.ValueChanged = function(self, val) -- overriding default function as it used to clamp result between mix and max, and we kinda want to go over the max if need be
+
+            if ( self.TextArea != vgui.GetKeyboardFocus() ) then
+                self.TextArea:SetValue( self.Scratch:GetTextValue() )
+            end
+
+            self.Slider:SetSlideX( self.Scratch:GetFraction( val ) )
+
+            self:OnValueChanged( val )
+
+        end
+
         slider:SetMinMax(min, max)
         slider:SetDecimals(0)
         slider:SetDefaultValue(default)

--- a/lua/smh/client/settings.lua
+++ b/lua/smh/client/settings.lua
@@ -4,6 +4,14 @@ local ConVarType = {
     Float = 3,
 }
 
+local GhostVars = {
+    smh_ghostprevframe = "GhostPrevFrame",
+    smh_ghostnextframe = "GhostNextFrame",
+    smh_ghostallentities = "GhostAllEntities",
+    smh_ghosttransparency = "GhostTransparency",
+    smh_onionskin = "OnionSkin"
+}
+
 local TYPED_CV = {}
 TYPED_CV.__index = TYPED_CV
 
@@ -42,6 +50,15 @@ local function CreateTypedConVar(type, name, defaultValue, helptext)
     }
     setmetatable(cv, TYPED_CV)
 
+    if GhostVars[name] then
+        cvars.AddChangeCallback(name, function(convar, oldvalue, newvalue)
+            if oldvalue == newvalue then return end
+
+            SMH.Controller.UpdateUISetting(GhostVars[name], newvalue)
+            SMH.Controller.UpdateGhostState()
+        end)
+    end
+
     return cv
 end
 
@@ -58,6 +75,7 @@ local ConVars = {
     SmoothPlayback = CreateTypedConVar(ConVarType.Bool, "smh_smoothplayback", false),
     EnableWorld = CreateTypedConVar(ConVarType.Bool, "smh_enableworldkeyframes", false),
 }
+
 
 local MGR = {}
 

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -771,6 +771,12 @@ function MGR.RefreshTimelineSettings()
     PropertiesMenu:UpdateTimelineSettings()
 end
 
+function MGR.UpdateUISetting(setting, value)
+    local settings = {}
+    settings[setting] = value
+    WorldClicker.Settings:ApplySettings(settings)
+end
+
 function MGR.SetTimeline(timeline)
     WorldClicker.MainMenu:UpdateTimelines(timeline)
     PropertiesMenu:UpdateTimelineInfo(timeline)

--- a/lua/smh/server/keyframe_manager.lua
+++ b/lua/smh/server/keyframe_manager.lua
@@ -220,7 +220,11 @@ function MGR.Copy(player, keyframeIds, frame, timeline)
             if not keyframe.Modifiers[name] then continue end
             EaseIn[name] = keyframe.EaseIn[name]
             EaseOut[name] = keyframe.EaseOut[name]
-            Mods[name] = keyframe.Modifiers[name]
+            if istable(keyframe.Modifiers[name]) then
+                Mods[name] = table.Copy(keyframe.Modifiers[name]) -- in case if we copy things like world keyframes
+            else
+                Mods[name] = keyframe.Modifiers[name]
+            end
         end
 
         local copiedKeyframe = SMH.KeyframeData:New(player, keyframe.Entity)

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -104,7 +104,7 @@ function MGR.StartPlayback(player, startFrame, endFrame, playbackRate, settings)
         EndFrame = endFrame,
         PlaybackRate = playbackRate,
         CurrentFrame = startFrame,
-		PrevFrame = startFrame - 1,
+        PrevFrame = startFrame - 1,
         Timer = 0,
         Settings = settings,
     }
@@ -131,10 +131,10 @@ hook.Add("Think", "SMHPlaybackManagerThink", function()
                     playback.Timer = 0
                 end
 
-				if playback.CurrentFrame ~= playback.PrevFrame then
-					playback.PrevFrame = playback.CurrentFrame
-					MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
-				end
+                if playback.CurrentFrame ~= playback.PrevFrame then
+                    playback.PrevFrame = playback.CurrentFrame
+                    MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
+                end
 
             end
         else

--- a/lua/smh/server/playback_manager.lua
+++ b/lua/smh/server/playback_manager.lua
@@ -104,6 +104,7 @@ function MGR.StartPlayback(player, startFrame, endFrame, playbackRate, settings)
         EndFrame = endFrame,
         PlaybackRate = playbackRate,
         CurrentFrame = startFrame,
+		PrevFrame = startFrame - 1,
         Timer = 0,
         Settings = settings,
     }
@@ -117,16 +118,24 @@ end
 hook.Add("Think", "SMHPlaybackManagerThink", function()
     for player, playback in pairs(ActivePlaybacks) do
         if not playback.Settings.SmoothPlayback or playback.Settings.TweenDisable then
+
             playback.Timer = playback.Timer + FrameTime()
             local timePerFrame = 1 / playback.PlaybackRate
+
             if playback.Timer >= timePerFrame then
+
                 playback.CurrentFrame = math.floor(playback.Timer / timePerFrame) + playback.StartFrame
                 if playback.CurrentFrame > playback.EndFrame then
                     playback.CurrentFrame = 0
                     playback.StartFrame = 0
                     playback.Timer = 0
                 end
-                MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
+
+				if playback.CurrentFrame ~= playback.PrevFrame then
+					playback.PrevFrame = playback.CurrentFrame
+					MGR.SetFrame(player, playback.CurrentFrame, playback.Settings)
+				end
+
             end
         else
             PlaybackSmooth(player, playback, playback.Settings)


### PR DESCRIPTION
Small tweaks:
- Optimized playback to not use load functions every tick but actually use it when new frame comes up, so default playback (not smooth one) should be even less performance heavy. Should be noticeable in not greatly optimized maps
- Physics recorder sliders will now update their values without a need to press enter when you go over slider's max limit
- Fixed issue with duplicated world keyframes writing their new values into each other
- Changing ghost related convars through console will update ghost state, so when you enter smh_ghostprevkeyframe it will show previous ghost as you enter the command rather than having to move playhead back and forth