### PR TITLE
Saved SMH animations are now "pretty printed" to be more readable and…

### DIFF
--- a/lua/smh/shared/saves.lua
+++ b/lua/smh/shared/saves.lua
@@ -165,7 +165,7 @@ function MGR.Save(path, serializedKeyframes)
     end
 
     path = SaveDir .. path .. ".txt"
-    local json = util.TableToJSON(serializedKeyframes)
+    local json = util.TableToJSON(serializedKeyframes, true)
     file.Write(path, json)
 end
 


### PR DESCRIPTION
… parsable. There is a tradeoff of slightly larger filesizes by doing this

Added an additional parameter to util.TableToJSON in MGR.Save() method of lua/smh/shared/saves.lua
This enables pretty printing when saving files
File size becomes roughly 50% larger but the end result is easier to parse and maintain in things like Git for version control on animation files for group animation projects.