### PR TITLE
Add extended renderer

### DIFF
--- a/lua/smh/client/concommands.lua
+++ b/lua/smh/client/concommands.lua
@@ -1,6 +1,6 @@
-local smh_startatone = CreateClientConVar("smh_startatone", 0, true, false, nil, 0, 1)
+local smh_startatone = CreateClientConVar("smh_startatone", 0, true, false, "Controls whether the timeline starts at 0 or 1.", 0, 1)
+local smh_render_cmd = CreateClientConVar("smh_render_cmd", "poster 1", true, false, "For smh_render, this string will be ran in the console for each frame.")
 CreateClientConVar("smh_currentpreset", "default", true, false)
-
 
 concommand.Add("+smh_menu", function()
     SMH.Controller.OpenMenu()
@@ -42,32 +42,29 @@ concommand.Add("smh_quicksave", function()
     SMH.Controller.QuickSave()
 end)
 
-concommand.Add("smh_makejpeg", function(pl, cmd, args)
-    local startframe
-    if args[1] then
-        startframe = args[1] - smh_startatone:GetInt()
+local function StartRender(startFrame, renderCmd)
+    if startFrame then
+        startFrame = startFrame - smh_startatone:GetInt() -- Implicit string->number. Normalizes startFrame to 0-indexed if smh_startatone is set.
+        if startFrame < 0 then startFrame = 0 end
     else
-        startframe = 0
+        startFrame = 0
     end
-    if startframe < 0 then startframe = 0 end
-    if startframe < SMH.State.PlaybackLength then
-        SMH.Controller.ToggleRendering(false, startframe)
+
+    if startFrame < SMH.State.PlaybackLength then
+        SMH.Controller.ToggleRendering(renderCmd, startFrame)
     else
         print("Specified starting frame is outside of the current Frame Count!")
     end
+end
+
+concommand.Add("smh_makejpeg", function(pl, cmd, args)
+    StartRender(args[1], "jpeg")
 end)
 
 concommand.Add("smh_makescreenshot", function(pl, cmd, args)
-    local startframe
-    if args[1] then
-        startframe = args[1] - smh_startatone:GetInt()
-    else
-        startframe = 0
-    end
-    if startframe < 0 then startframe = 0 end
-    if startframe < SMH.State.PlaybackLength then
-        SMH.Controller.ToggleRendering(true, startframe)
-    else
-        print("Specified starting frame is outside of the current Frame Count!")
-    end
+    StartRender(args[1], "screenshot")
+end)
+
+concommand.Add("smh_render", function(pl, cmd, args)
+    StartRender(args[1], smh_render_cmd:GetString())
 end)

--- a/lua/smh/client/controller.lua
+++ b/lua/smh/client/controller.lua
@@ -307,13 +307,13 @@ function CTRL.ShouldHighlight()
     return SMH.UI.IsOpen()
 end
 
-function CTRL.ToggleRendering(useScreenshot, StartFrame)
+function CTRL.ToggleRendering(renderCmd, StartFrame)
     if SMH.PhysRecord.IsActive() then return end
 
     if SMH.Renderer.IsRendering() then
         SMH.Renderer.Stop()
     else
-        SMH.Renderer.Start(useScreenshot, StartFrame)
+        SMH.Renderer.Start(renderCmd, StartFrame)
     end
 end
 

--- a/lua/smh/client/renderer.lua
+++ b/lua/smh/client/renderer.lua
@@ -1,4 +1,4 @@
-local UseScreenshot = false
+local RenderCmd = ""
 local IsRendering = false
 
 local MGR = {}
@@ -21,12 +21,7 @@ local function RenderTick()
 
     local newPos = SMH.State.Frame + 1
 
-    local command = "jpeg"
-    if UseScreenshot then
-        command = "screenshot"
-    end
-
-    RunConsoleCommand(command)
+    LocalPlayer():ConCommand(RenderCmd)
 
     if newPos >= SMH.State.PlaybackLength then
         MGR.Stop()
@@ -43,8 +38,9 @@ local function RenderTick()
 
 end
 
-function MGR.Start(useScreenshot, StartFrame)
-    UseScreenshot = useScreenshot
+function MGR.Start(renderCmd, StartFrame)
+    if not isstring(renderCmd) then error(string.format("Tried to start a render with a non-string renderCmd: %s: %q", type(renderCmd), tostring(renderCmd))) end
+    RenderCmd = renderCmd
 
     IsRendering = true
     SMH.Controller.SetRendering(IsRendering)


### PR DESCRIPTION
This PR adds the ability to run a specific command for rendering, instead of only `jpeg` or `screenshot`.

The convar `smh_render_cmd` sets up a command to run each frame of the render. By default, this is `poster 1`. The entire string of this convar is used when `smh_render` is called to render each frame. This user-defined approach allows for far more flexibility, such as running two render operations at once using the semicolon, such as `poster_soft 2;poster 2`.

To facilitate this functionality, this PR rewrites the renderer to be passed the string of the concommand to run on the client, instead of passing a boolean to control the difference of `jpeg`/`screenshot`. This also has the benefit of generalizing the code for `smh_makejpeg`, `smh_makescreenshot`, and `smh_render` into one.

This PR also includes two small, miscellaneous changes to `smh_startatone` that help explain their functionality. These confused me as I worked on them, so I documented them a little further to help explain their purpose.

### Known issues:
- Currently, using any form of `poster` has a high chance to overwrite the same image. Facepunch/garrysmod-issues#6134 claims this is fixed, but it's not been pushed to the main branch yet, so this PR should be held back until it is.