### PR TITLE
Keyframe Delete Concommand

### DIFF
--- a/lua/smh/client/concommands.lua
+++ b/lua/smh/client/concommands.lua
@@ -10,6 +10,14 @@ concommand.Add("smh_record", function()
     SMH.Controller.Record()
 end)
 
+concommand.Add("smh_delete", function()
+	local frame = SMH.State.Frame
+	local ids = SMH.UI.GetKeyframesOnFrame(frame)
+	if not ids then return end
+
+    SMH.Controller.DeleteKeyframe(ids)
+end)
+
 concommand.Add("smh_next", function()
     local pos = SMH.State.Frame + 1
     if pos >= SMH.State.PlaybackLength then

--- a/lua/smh/client/ui.lua
+++ b/lua/smh/client/ui.lua
@@ -855,4 +855,15 @@ function MGR.SetWorldData(console, push, release)
     PropertiesMenu:ShowWorldSettings(console, push, release)
 end
 
+function MGR.GetKeyframesOnFrame(frame)
+	if not FrameToKeyframe[frame] then return nil end
+	local ids = {}
+
+	for id, mod in pairs(KeyframePointers[FrameToKeyframe[frame]]:GetIDs()) do
+		table.insert(ids, id)
+	end
+
+	return ids
+end
+
 SMH.UI = MGR

--- a/lua/smh/shared/saves.lua
+++ b/lua/smh/shared/saves.lua
@@ -269,7 +269,7 @@ function MGR.Save(path, serializedKeyframes, player)
     end
 
     path = SaveDir .. (PlayerPath[player] or "") .. path .. ".txt"
-    local json = util.TableToJSON(serializedKeyframes, true)
+    local json = util.TableToJSON(serializedKeyframes)
     file.Write(path, json)
 end
 


### PR DESCRIPTION
Adds "smh_delete" console command to delete a keyframe that the playhead points to.
PrettyPrint from save JSONs was disabled, though probably in the future there could be an option from UI on whether to set it on or off.